### PR TITLE
Remove `NPM_TOKEN` from node-micro example

### DIFF
--- a/node-micro/Dockerfile
+++ b/node-micro/Dockerfile
@@ -1,6 +1,4 @@
 FROM mhart/alpine-node:10 as base
-ARG NPM_TOKEN
-RUN echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
 WORKDIR /usr/src
 COPY package.json yarn.lock /usr/src/
 RUN yarn --production


### PR DESCRIPTION
It's not necessary for the demo, and proper `NPM_TOKEN` usage
is better suited for the docs than these hello world examples.

Closes #59.