### PR TITLE
Better to poll on alpine or in containers to prevent issues inotify exceptions

### DIFF
--- a/dotnetcore/Dockerfile
+++ b/dotnetcore/Dockerfile
@@ -13,6 +13,7 @@ RUN dotnet publish -c Release -o out
 
 
 FROM microsoft/dotnet:2.1-aspnetcore-runtime-alpine AS runtime
+ENV DOTNET_USE_POLLING_FILE_WATCHER=true
 WORKDIR /app
 COPY --from=build /app/aspnetapp/out ./
 ENTRYPOINT ["dotnet", "aspnetapp.dll"]


### PR DESCRIPTION
Better to poll on alpine or in containers to prevent issues like "inotify exceptions user limit (8192) on the number of inotify instances has been reached." with the .NET file watcher