### PR TITLE
Fix README of next.js example

### DIFF
--- a/node-next.js/README.md
+++ b/node-next.js/README.md
@@ -60,7 +60,7 @@ WORKDIR /usr/src
 ENV NODE_ENV="production"
 COPY --from=base /usr/src .
 EXPOSE 3000
-CMD ["yarn", "start"]
+CMD ["node", "./node_modules/.bin/next", "start"]
 ```
 
 ## Step 5: Set files to ignore with Docker


### PR DESCRIPTION
In the Dockerfile section of the README for the next.js example, the CMD line won't work -- the mhart/alpine-node:base-10 docker image doesn't install yarn. This PR updates the README with the contents of the real Dockerfile, which has a working CMD.