### PR TITLE
Fix (#106) Laravel deploy failing

### DIFF
--- a/php-laravel/Dockerfile
+++ b/php-laravel/Dockerfile
@@ -6,7 +6,7 @@ COPY composer.json composer.json
 COPY composer.lock composer.lock
 
 RUN composer install --ignore-platform-reqs --no-interaction \
-    --no-plugins --no-scripts --prefer-dist --no-dev
+    --no-plugins --no-scripts --prefer-dist
 
 FROM zeit/wait-for:0.2 as wait
 
@@ -25,6 +25,8 @@ COPY docker/nginx.conf /etc/nginx/
 WORKDIR /var/www/laravel
 COPY . .
 RUN mkdir -p bootstrap/cache storage/app storage/framework/cache storage/framework/sessions storage/framework/views storage/logs
+# Only possible to clear route cache via `artisan` if your app has no closures in its routes:
+# https://github.com/laravel/framework/issues/22034
 RUN php artisan route:cache
 RUN chown -R nobody:nobody /var/www/laravel
 


### PR DESCRIPTION
Using the `--no-dev` flag on the `composer` command [was causing the error](https://github.com/laravel/framework/issues/24383#issue-327858576): 

```
In Application.php line 708:

  Class 'NunoMaduro\Collision\Adapters\Laravel\CollisionServiceProvider' not found
```

While removing the flag does make the container slightly bigger, it allows Laravel to build and deploy on Zeit. The current example Docker code does not.

I also added a note/comment regarding `RUN php artisan route:cache`. There is currently [a bug](https://github.com/laravel/framework/issues/22034) in Laravel that will result in an error if the routes file contains a closure (which a lot of projects do) and `php artisan route:cache` is run. The example code will run fine, however (and the Docker image will be built) since the routes file contains only one route. 