### PR TITLE
Add go middleware example

### DIFF
--- a/go/index.go
+++ b/go/index.go
@@ -6,20 +6,20 @@ import (
 	"net/http"
 )
 
-func WithLogging(next http.HandlerFunc) http.HandlerFunc {
+func Logging(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Logged connection from %s", r.RemoteAddr)
 		next.ServeHTTP(w, r)
 	}
 }
 
-func WithTracing(next http.HandlerFunc) http.HandlerFunc {
+func Tracing(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Tracing request for %s", r.RequestURI)
 		next.ServeHTTP(w, r)
 	}
 }
 
-func Handler(w http.ResponseWriter, r *http.Request) {
+func HelloWorld(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Hello from Go on Now Lambda!")
 }

--- a/go/index.go
+++ b/go/index.go
@@ -2,8 +2,23 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 )
+
+func WithLogging(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("Logged connection from %s", r.RemoteAddr)
+		next.ServeHTTP(w, r)
+	}
+}
+
+func WithTracing(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("Tracing request for %s", r.RequestURI)
+		next.ServeHTTP(w, r)
+	}
+}
 
 func Handler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Hello from Go on Now Lambda!")

--- a/go/now.json
+++ b/go/now.json
@@ -2,6 +2,6 @@
     "version": 2,
     "name": "go",
     "builds": [
-        { "src": "*.go", "use": "@now/go" }
+        { "src": "*.go", "use": "@bluebeel/go" }
     ]
 }


### PR DESCRIPTION
I updated the example according to my [**PR#3**](https://github.com/zeit/now-builders/pull/3) in the repo **[now-builders](https://github.com/zeit/now-builders)** where I added the possibility to put middlewares.

To test the example you must use my package ([**@bluebeel/go**](https://www.npmjs.com/package/@bluebeel/go)) in the build of the file _now.json_ for the moment the time that the PR on the other repo is accepted.