### PR TITLE
Add missing build script preventing CRA deployment.

### DIFF
--- a/create-react-app/README.md
+++ b/create-react-app/README.md
@@ -30,6 +30,18 @@ By just adding the version key, we can specify which Now Platform to use. We als
 }
 ```
 
+Add the `now-build` script to `package.json`:
+
+```
+"scripts": {
+  "now-build": "npm run build && mv build dist",
+  "start": "react-scripts start",
+  "build": "react-scripts build",
+  "test": "react-scripts test",
+  "eject": "react-scripts eject"
+},
+```
+
 We are now ready to deploy the app.
 
 ```


### PR DESCRIPTION
Hi!  Without this clarification, Now users may copy from other `package.json` files in the examples, which use `"now-build": "npm run build && mv public dist"`.  

However this is incorrect for CRA, as the CRA team builds to a `build` folder.

The correct CRA-specific build step is `"now-build": "npm run build && mv build dist"`.

This additional clarification is consistent with the Vue readme.