### PR TITLE
Fix typos and highlight builder names

### DIFF
--- a/create-react-app/README.md
+++ b/create-react-app/README.md
@@ -24,7 +24,7 @@ First we need to add a command into the `package.json` file.
 
 Then we need to add a `now.json` file to specify we want to use our Platform V2.
 
-By just adding the version key, we can specify which Now Platform to use. We also need to define each builders we would like to use, in this case we are going to use @now/static-build to build and deploy our React application selecting the `package.json` as our entry point. We will also define a name for our project (optional). The `routes` property makes sure requests like `/non-existent-page` are routed to the Create React App `index.html`.
+By just adding the version key, we can specify which Now Platform to use. We also need to define each builders we would like to use, in this case we are going to use `@now/static-build` to build and deploy our React application selecting the `package.json` as our entry point. We will also define a name for our project (optional). The `routes` property makes sure requests like `/non-existent-page` are routed to the Create React App `index.html`.
 
 ```json
 {

--- a/gatsby/README.md
+++ b/gatsby/README.md
@@ -14,7 +14,7 @@ npx gatsby new <project name>
 
 First we need to add a `now.json` file to specify we want to use our Platform V2.
 
-By just adding the version key, we can specify which Now Platform to use. We also need to define each builders we would like to use, in this case we are going to use @now/static-build to build and deploy our Gatsby application selecting the `package.json` as our entry point. We will also define a name for our project (optional).
+By just adding the version key, we can specify which Now Platform to use. We also need to define each builders we would like to use, in this case we are going to use `@now/static-build` to build and deploy our Gatsby application selecting the `package.json` as our entry point. We will also define a name for our project (optional).
 
 ```json
 {

--- a/go/README.md
+++ b/go/README.md
@@ -23,7 +23,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 First we need to add a `now.json` file to specify we want to use our Platform V2.
 
-By just adding the version key, we can specify which Now Platform to use. We also need to define each builders we would like to use, in this case we are going to use @now/go to build and deploy the all GoLang files. We will also define a name for our project (optional).
+By just adding the version key, we can specify which Now Platform to use. We also need to define each builders we would like to use, in this case we are going to use `@now/go` to build and deploy the all GoLang files. We will also define a name for our project (optional).
 
 ```
 {

--- a/nextjs-static/README.md
+++ b/nextjs-static/README.md
@@ -77,7 +77,7 @@ First you need to tell Now how to build the app using the `now-build` script in 
 
 First we need to add a `now.json` file to specify we want to use our Platform V2.
 
-By just adding the version key, we can specify which Now Platform to use. We also need to define each builders we would like to use, in this case we are going to use @now/next to build and deploy our Next.js application selecting the `next.config.js` as our entry point. We will also define a name for our project (optional).
+By just adding the version key, we can specify which Now Platform to use. We also need to define each builders we would like to use, in this case we are going to use `@now/static-build` to build and deploy our Next.js application selecting the `package.json` as our entry point. We will also define a name for our project (optional).
 
 ```json
 {

--- a/nextjs/README.md
+++ b/nextjs/README.md
@@ -79,7 +79,7 @@ module.exports = {}
 
 First we need to add a `now.json` file to specify we want to use our Platform V2.
 
-By just adding the version key, we can specify which Now Platform to use. We also need to define which builders we would like to use, in this case we are going to use @now/next to build and deploy our Next.js application selecting the `next.config.js` as our entry point. We will also define a name for our project (optional).
+By just adding the version key, we can specify which Now Platform to use. We also need to define which builders we would like to use, in this case we are going to use `@now/next` to build and deploy our Next.js application selecting the `next.config.js` as our entry point. We will also define a name for our project (optional).
 
 ```
 {

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -16,7 +16,7 @@ module.exports = (req, res) => {
 
 First we need to add a `now.json` file to specify we want to use our Platform V2.
 
-By just adding the version key, we can specify which Now Platform to use. We also need to define each builders we would like to use, in this case we are going to use @now/node to build and deploy the all JavaScript files. We will also define a name for our project (optional).
+By just adding the version key, we can specify which Now Platform to use. We also need to define each builders we would like to use, in this case we are going to use `@now/node` to build and deploy the all JavaScript files. We will also define a name for our project (optional).
 
 ```
 {

--- a/php-7/README.md
+++ b/php-7/README.md
@@ -14,7 +14,7 @@ In this example we will be deploying a simple "Hello World" example with PHP.
 
 First we need to add a `now.json` file to specify we want to use our Platform V2.
 
-By just adding the version key, we can specify which Now Platform to use. We also need to define each builders we would like to use, in this case we are going to use @now/php to build and deploy the all PHP files. We will also define a name for our project (optional).
+By just adding the version key, we can specify which Now Platform to use. We also need to define each builders we would like to use, in this case we are going to use `@now/php` to build and deploy the all PHP files. We will also define a name for our project (optional).
 
 ```
 {

--- a/python/README.md
+++ b/python/README.md
@@ -23,7 +23,7 @@ class handler(BaseHTTPRequestHandler):
 
 First we need to add a `now.json` file to specify we want to use our Platform V2.
 
-By just adding the version key, we can specify which Now Platform to use. We also need to define each builders we would like to use, in this case we are going to use @now/python to build and deploy the all Python files. We will also define a name for our project (optional).
+By just adding the version key, we can specify which Now Platform to use. We also need to define each builders we would like to use, in this case we are going to use `@now/python` to build and deploy the all Python files. We will also define a name for our project (optional).
 
 ```
 {

--- a/redirect/README.md
+++ b/redirect/README.md
@@ -6,7 +6,7 @@ In this example we will be deploying a simple redirect from a `www` domain to a 
 
 First, we need to create an empty `index.html`. Then we need to add a `now.json` file to specify we want to use our Platform V2.
 
-By just adding the version key, we can specify which Now Platform to use. We also need to define each builders we would like to use, in this case we are going to use @now/static to properly deploy our `index.html`. We will then work with our `"routes"` configuration to define the behavior of our redirect. In this case, we will set a status header with the code `301` and also forward the path to our redirect location.
+By just adding the version key, we can specify which Now Platform to use. We also need to define each builders we would like to use, in this case we are going to use `@now/static` to properly deploy our `index.html`. We will then work with our `"routes"` configuration to define the behavior of our redirect. In this case, we will set a status header with the code `301` and also forward the path to our redirect location.
 
 ```
 {

--- a/vue/readme.md
+++ b/vue/readme.md
@@ -20,7 +20,7 @@ vue create <project name>
 
 First we need to add a `now.json` file to specify we want to use our Platform V2.
 
-By just adding the version key, we can specify which Now Platform to use. We also need to define each builders we would like to use, in this case we are going to use @now/static-build to build and deploy our Vue application selecting the `package.json` as our entry point. We will also define a name for our project (optional). The `routes` property makes sure requests like `/non-existent-page` are routed to the Vue `index.html`.
+By just adding the version key, we can specify which Now Platform to use. We also need to define each builders we would like to use, in this case we are going to use `@now/static-build` to build and deploy our Vue application selecting the `package.json` as our entry point. We will also define a name for our project (optional). The `routes` property makes sure requests like `/non-existent-page` are routed to the Vue `index.html`.
 
 ```
 {

--- a/vuepress/README.md
+++ b/vuepress/README.md
@@ -77,7 +77,7 @@ First you need to tell Now how to build the app using the `now-build` script in 
 
 Then we need to add a `now.json` file to specify we want to use our Platform V2.
 
-By just adding the version key, we can specify which Now Platform to use. We also need to define each builders we would like to use, in this case we are going to use @now/static-build to build and deploy our Vuepress application selecting the `package.json` as our entry point. We will also define a name for our project (optional).
+By just adding the version key, we can specify which Now Platform to use. We also need to define each builders we would like to use, in this case we are going to use `@now/static-build` to build and deploy our Vuepress application selecting the `package.json` as our entry point. We will also define a name for our project (optional).
 
 ```json
 {


### PR DESCRIPTION
It seems that https://zeit.co/examples/nextjs-static/ have typos in the paragraph describing `now.json` example.

I also highlighted builder names in those paragraphs in all README files.

If I'm wrong and changes aren't necessary, please close this PR 😓