### PR TITLE
Use correct distDir for Gatsby output

### DIFF
--- a/gatsby/README.md
+++ b/gatsby/README.md
@@ -21,12 +21,12 @@ By just adding the version key, we can specify which Now Platform to use. We als
     "version": 2,
     "name": "gatsby",
     "builds": [
-        { "src": "package.json", "use": "@now/static-build", "config": {"distDir": "dist"} }
+        { "src": "package.json", "use": "@now/static-build", "config": {"distDir": "public"} }
     ]
 }
 ```
 
-Now, since it uses `@now/static-build`, we need to also include a script in `package.json` named `"now-build"`. This script specifies what command now will run on the server to "build" your application. Also, notice that this builder accepts a configuration called `"distDir"`, that will move all production files to the given folder.
+Now, since it uses `@now/static-build`, we need to also include a script in `package.json` named `"now-build"`. This script specifies what command now will run on the server to "build" your application. Also, notice that this builder accepts a configuration called `"distDir"`, which should point to the output directory of our build script.
 
 We are now ready to deploy the app.
 

--- a/gatsby/now.json
+++ b/gatsby/now.json
@@ -2,6 +2,6 @@
     "version": 2,
     "name": "gatsby",
     "builds": [
-        { "src": "package.json", "use": "@now/static-build", "config": {"distDir": "dist"} }
+        { "src": "package.json", "use": "@now/static-build", "config": {"distDir": "public"} }
     ]
 }


### PR DESCRIPTION
When running this example I found that the resulting deployment served 404s because the distDir didn't match Gatsby's build output.