### PR TITLE
CRA example docs for serving from custom locations

### DIFF
--- a/create-react-app/README.md
+++ b/create-react-app/README.md
@@ -56,6 +56,14 @@ We also need to include a script in `package.json` named `"now-build"` that spec
 }
 ```
 
+The routes section of the `now.json` configuration file is used to serve files present in the `dist` folder, as part of the `now-build` script.  The example `routes` array in the `now.json` configuration object above will serve files that create-react-app utilizes by default.  If there are any additional files or folders, you will need to add those to the `routes` array.  For example, if there is a `photos` subdirectory:
+
+```
+"routes": [
+        ...
+        {"src": "^/photos/(.*)", "dest": "/photos/$1"},
+```
+
 We are now ready to deploy the app.
 
 ```


### PR DESCRIPTION
I had some 404s for some photos when I converted my CRA project from now 1 to 2.  I think the following note in the docs for this example would have helped me understand more of what the routes were doing.

As a side note (unrelated to the doc change, this is an enhancement proposal), it does seem a bit strange to explicitly write this out, as it basically mimics the dist file naming structure.  I think a sane default would be, if it is in the dist directory and is not explicitly mentioned in the routes array, it is routed to by default.

```
"routes": [
      {"src": "^/static/(.*)", "dest": "/static/$1"},
      {"src": "^/photos/(.*)", "dest": "/photos/$1"},
      {"src": "^/favicon.ico", "dest": "/favicon.ico"},
      {"src": "^/asset-manifest.json", "dest": "/asset-manifest.json"},
      {"src": "^/manifest.json", "dest": "/manifest.json"},
      {"src": "^/service-worker.js", "headers": {"cache-control": "s-maxage=0"}, "dest": "/service-worker.js"},
      {"src": "^/precache-manifest.(.*)", "dest": "/precache-manifest.$1"},
      {"src": "^/(.*)", "dest": "/index.html"}
  ]
```