### PR TITLE
Add .nowignore to nodejs-express example

### DIFF
--- a/nodejs-express/.nowignore
+++ b/nodejs-express/.nowignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Hello folks,

I read [this doc](https://zeit.co/docs/v2/deployments/official-builders/node-js-server-now-node-server/) and see that it suggests adding `node_modules` to `.nowignore`.

I think it makes sense to add this to example as well.

Please let me know if this makes sense.

Thanks!