### PR TITLE
Add routes to now.json

### DIFF
--- a/nodejs-express/README.md
+++ b/nodejs-express/README.md
@@ -20,7 +20,11 @@ By adding the `version` key to the `now.json` file, we can specify which Now Pla
 
 We also need to define each builders we would like to use. [Builders](https://zeit.co/docs/v2/deployments/builders/overview/) are modules that take a deployment's source and return an output, consisting of [either static files or dynamic Lambdas](https://zeit.co/docs/v2/deployments/builds/#sources-and-outputs).
 
-In this case we are going to use `@now/node-server` in order to start a Node.js server using Express. We will also define a name for our project (optional).
+In this case we are going to use `@now/node-server` in order to start a Node.js server using Express.
+
+If Express app has more than 1 route defined, we need to add [`routes`](https://zeit.co/docs/v2/deployments/configuration#routes).
+
+We will also define a name for our project (optional).
 
 ```json
 {
@@ -28,6 +32,9 @@ In this case we are going to use `@now/node-server` in order to start a Node.js 
     "name": "nodejs-express",
     "builds": [
         { "src": "index.js", "use": "@now/node-server" }
+    ],
+    "routes": [
+        { "src": "/(.*)", "dest": "/index.js" }
     ]
 }
 ```

--- a/nodejs-express/index.js
+++ b/nodejs-express/index.js
@@ -4,7 +4,12 @@ const port = process.env.PORT || 3000
 const app = express()
 
 app.get('/', (req, res) => {
-    res.send('<h1><marquee direction=right>Hello from Express on Now 2.0!</marquee></h1>')
+    res.send('<h1><marquee direction=right>Hello from Express path / on Now 2.0!</marquee></h1>')
+    res.end()
+})
+
+app.get('/about', (req, res) => {
+    res.send('<h1><marquee direction=left>Hello from Express path /about on Now 2.0!</marquee></h1>')
     res.end()
 })
 

--- a/nodejs-express/now.json
+++ b/nodejs-express/now.json
@@ -1,10 +1,10 @@
 {
     "version": 2,
     "name": "nodejs-express",
-    "routes": [
-        { "src": "/(.*)", "dest": "/index.js" }
-    ],
     "builds": [
         { "src": "index.js", "use": "@now/node-server" }
+    ],
+    "routes": [
+        { "src": "/(.*)", "dest": "/index.js" }
     ]
 }

--- a/nodejs-express/now.json
+++ b/nodejs-express/now.json
@@ -1,6 +1,9 @@
 {
     "version": 2,
     "name": "nodejs-express",
+    "routes": [
+        { "src": "/(.*)", "dest": "/index.js" }
+    ],
     "builds": [
         { "src": "index.js", "use": "@now/node-server" }
     ]


### PR DESCRIPTION
Hi folks,

I am playing with deploying Express app to zeit and face the routing issue like [this one](https://spectrum.chat/zeit?thread=361c8ce4-887a-4b66-b64d-90f739452333)

I think it makes sense to add `routes` section to `now.json` so newbies like me will face less problems with Express routing in future.

Please let me know your thoughts.

Thanks