### PR TITLE
[RFC] Add CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contributing
+
+When contributing to this repository, make sure your example fits the purpose of the repository. 
+When in doubt, create an issue to discuss the change you wish to make. 
+
+Please note we have a code of conduct, please follow it in all your interactions with the project.
+
+## General Guidelines
+
+1. Make sure your example is deployable. 
+   Nothing brings more frustration than a minimum example failing, therefore please deploy your 
+   contribution if the change is significant.
+1. A good `README.md` is the best "welcome mat" for your example. This repository has many examples, 
+   it is advised to copy & paste a `README.md` from another example and adapt to your contribution, 
+   for better navigation across examples.
+1. `now.json` should always be present. Developers expect the code to be as ready as possible, 
+   which means having a correct `now.json` is expected.
+
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,13 +7,11 @@ Please note we have a code of conduct, please follow it in all your interactions
 
 ## General Guidelines
 
-1. Make sure your example is deployable. 
-   Nothing brings more frustration than a minimum example failing, therefore please deploy your 
-   contribution if the change is significant.
-1. A good `README.md` is the best "welcome mat" for your example. This repository has many examples, 
+1. Make sure your example is deployable and works perfectly.
+2. A good `README.md` is the best "welcome mat" for your example. This repository has many examples, 
    it is advised to copy & paste a `README.md` from another example and adapt to your contribution, 
    for better navigation across examples.
-1. `now.json` should always be present. Developers expect the code to be as ready as possible, 
+3. `now.json` should always be present. Developers expect the code to be as ready as possible, 
    which means having a correct `now.json` is expected.
 
 ## Code of Conduct


### PR DESCRIPTION
The addition of `CONTRIBUTING.md` file should state clearly what is expected from contributions to this repository.
This is an effort to move towards a repository with more entropy, with clarity about patterns and standards.
It also includes a "code of conduct".
Let's discuss if this is good or not for `now-examples`!