### PR TITLE
Update Next News example to use `target=serverless` with Next

### DIFF
--- a/nextjs-news/next.config.js
+++ b/nextjs-news/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  target: 'serverless'
+}

--- a/nextjs-news/package.json
+++ b/nextjs-news/package.json
@@ -2,21 +2,18 @@
   "name": "next-news",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.1.2",
     "isomorphic-fetch": "^2.2.1",
-    "ms": "^1.0.0",
-    "next-server": "^7.0.2-canary.18",
+    "ms": "^2.1.1",
+    "next": "^8.0.0-canary.2",
     "nprogress": "^0.2.0",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4",
-    "url-parse": "^1.1.8"
-  },
-  "devDependencies": {
-    "next": "^7.0.2-canary.18"
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0",
+    "url-parse": "^1.4.4"
   },
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "now-build": "next build"
   }
 }


### PR DESCRIPTION
This pull request updates the `next-news` example to build with the new `target: "serverless"` build method with Next.js.