### PR TITLE
Added `headers` and `status` to monorepo example

### DIFF
--- a/monorepo/now.json
+++ b/monorepo/now.json
@@ -18,7 +18,7 @@
           "dest": "/www/$1",
           "headers": {
             "x-request-path": "$1",
-            "cache-control": "max-age=1337"
+            "cache-control": "max-age=86400"
           }
         },
         {

--- a/monorepo/now.json
+++ b/monorepo/now.json
@@ -17,8 +17,7 @@
           "src": "/(.*)",
           "dest": "/www/$1",
           "headers": {
-            "x-request-path": "$1",
-            "cache-control": "max-age=86400"
+            "x-request-path": "$1"
           }
         },
         {

--- a/monorepo/now.json
+++ b/monorepo/now.json
@@ -1,4 +1,5 @@
 {
+    "name": "monorepo",
     "version": 2,
     "builds": [
         { "src": "www/package.json", "use": "@now/next" },
@@ -8,7 +9,24 @@
         { "src": "api/node/*.js", "use": "@now/node" }
     ],
     "routes": [
-        { "src": "/api/(.*)", "dest": "/api/$1" },
-        { "src": "/(.*)", "dest": "/www/$1" }
+        {
+          "src": "/api/(.*)",
+          "dest": "/api/$1"
+        },
+        {
+          "src": "/(.*)",
+          "dest": "/www/$1",
+          "headers": {
+            "x-request-path": "$1",
+            "cache-control": "max-age=1337"
+          }
+        },
+        {
+          "src": "/redirect-test",
+          "status": 302,
+          "headers": {
+            "location": "https://google.com"
+          }
+        }
     ]
 }


### PR DESCRIPTION
Like this, the monorepo can continue to stay the mother of all examples because it will showcase all of the most important features of a Now 2.0 app.