### PR TITLE
Update redirect example to be a little more clear

### DIFF
--- a/redirect/README.md
+++ b/redirect/README.md
@@ -4,7 +4,7 @@ In this example we will be deploying a simple redirect from a `www` domain to a 
 
 ### Deploy with Now
 
-Create a new folder on your local machine and create a new `now.json` file. To redirect, you only need to use the `routes` property of a `now.json` file (no need to have a `build` property in there, since it's just doing a redirect).
+Create a new folder on your local machine and create a new `now.json` file. To redirect, you only need to use the `routes` property of a `now.json` file (no need to have a `builds` property in there, since it's just doing a redirect).
 
 By adding the `version` key to the `now.json` file, we can specify to use the latest Now Platform version to use `routes`.
 

--- a/redirect/README.md
+++ b/redirect/README.md
@@ -1,10 +1,10 @@
 # Redirect
 
-In this example we will be deploying a simple redirect from a `www` domain to a naked one.
+In this example we will be deploying a simple redirect from a `www` domain to a naked one. This will be an entirely separate deployment from your main one. You just need to deploy it one time and then you can forget about it.
 
 ### Deploy with Now
 
-To redirect, you only need to use the `routes` property of a `now.json` file.
+Create a new folder on your local machine and create a new `now.json` file. To redirect, you only need to use the `routes` property of a `now.json` file (no need to have a `build` property in there, since it's just doing a redirect).
 
 By adding the `version` key to the `now.json` file, we can specify to use the latest Now Platform version to use `routes`.
 
@@ -36,4 +36,4 @@ Once the deployment is created, you can [alias it](https://zeit.co/docs/v2/domai
 now alias
 ```
 
-Now, when visiting either the alias or deployment URL, the visitor will get redirected to the location set via the `routes` in the `now.json` file.
+Now, when visiting either the alias (www.example.sh) or deployment URL, the visitor will get redirected to the location set via the `routes` in the `now.json` file.


### PR DESCRIPTION
I was a tad confused when I posted in [Spectrum](https://spectrum.chat/zeit/general/redirect-www-to-non-www~c1fc37b7-981e-4d5a-9bcb-b4ab35e0e824) and didn't realize redirects needed to be handled in an entirely separate deployment. So I've just modified the readme a bit to try be a little more clear about it.