### PR TITLE
Provide info about Deep API Account in Readme.md

### DIFF
--- a/express/README.md
+++ b/express/README.md
@@ -5,13 +5,20 @@
 This repo is an example app featured in [this blog post](https://zeit.co/blog/serverless-express-js-lambdas-with-now-2). Please be sure to read the blog post to fully understand the concepts demonstrated here.
 
 ## Getting Started
-
+### Setup Twitter Accounts/Tokens to Auth
 1. Create an app on [Twitter for Developers](https://developer.twitter.com/).
-1. Add the required [secrets](https://zeit.co/docs/v2/deployments/environment-variables-and-secrets/) (found in `now.json`) to your Now account.
-   - You'll need your Twitter **consumer API keys**.
-   - `COOK_KEY` can be any arbitrary string. It is used to sign the user's cookie.
 1. Update the callback URL (`routes/login/index.js`, line 14) to be one from your Twitter app.
+### Setup DeepAPI Account for image processing
+1. Create an account on [DeepAI ](https://deepai.org/)
+1. Get your deep api from the [Deep AI Dashboard](https://deepai.org/dashboard)
+### Store the Tokens and Keys as now secrets
+1. Add the required [secrets](https://zeit.co/docs/v2/deployments/environment-variables-and-secrets/) (found in `now.json`) to your Now account.
+   - You'll need your Twitter **consumer API keys** and **DeepAI API key** you created above 
+   - `COOK_KEY` can be any arbitrary string. It is used to sign the user's cookie.
+    The now.json file uses ``@secret-name`` so that the keys will be available to the deployment, but not saved in version control.
+#### Configure cookie domain
 1. Update the [cookie domain](https://github.com/zeit/now-examples/blob/5616954f9a3875e30c97f9c9b58e3869ddf33c50/express/middlewares/cookieSession.js#L6) with a [`now` alias](https://zeit.co/docs/v2/domains-and-aliases/aliasing-a-deployment/) of your choosing.
+### Deploy it on now.sh
 1. Deploy this project with `now`.
 1. Alias your deployment to match your cookie domain: `now alias [deployment-url] [chosen-alias]`.
 1. 🎉

--- a/express/README.md
+++ b/express/README.md
@@ -15,7 +15,7 @@ This repo is an example app featured in [this blog post](https://zeit.co/blog/se
 1. Add the required [secrets](https://zeit.co/docs/v2/deployments/environment-variables-and-secrets/) (found in `now.json`) to your Now account.
    - You'll need your Twitter **consumer API keys** and **DeepAI API key** you created above 
    - `COOK_KEY` can be any arbitrary string. It is used to sign the user's cookie.
-    The now.json file uses ``@secret-name`` so that the keys will be available to the deployment, but not saved in version control.
+    The now.json file uses `@secret-name` so that the keys will be available to the deployment, but not saved in version control.
 #### Configure cookie domain
 1. Update the [cookie domain](https://github.com/zeit/now-examples/blob/5616954f9a3875e30c97f9c9b58e3869ddf33c50/express/middlewares/cookieSession.js#L6) with a [`now` alias](https://zeit.co/docs/v2/domains-and-aliases/aliasing-a-deployment/) of your choosing.
 ### Deploy it on now.sh

--- a/express/README.md
+++ b/express/README.md
@@ -9,7 +9,7 @@ This repo is an example app featured in [this blog post](https://zeit.co/blog/se
 1. Create an app on [Twitter for Developers](https://developer.twitter.com/).
 1. Update the callback URL (`routes/login/index.js`, line 14) to be one from your Twitter app.
 ### Setup DeepAPI Account for image processing
-1. Create an account on [DeepAI ](https://deepai.org/)
+1. Create an account on [DeepAI](https://deepai.org/).
 1. Get your deep api from the [Deep AI Dashboard](https://deepai.org/dashboard)
 ### Store the Tokens and Keys as now secrets
 1. Add the required [secrets](https://zeit.co/docs/v2/deployments/environment-variables-and-secrets/) (found in `now.json`) to your Now account.


### PR DESCRIPTION
Cleaned up the readme a bit to save anyone time who wants to actually try to get this working.  This edit will save users time.  Otherwise, they have to walk through the code to find the  URL to the DeepAI service.  The token is required to when configuring this example.

Also added a bit of grouping of the steps with subheads (e.g. "Store the Tokens and Keys as now secrets")