### PR TITLE
Update Next.js template to include setup scripts.

### DIFF
--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -2,8 +2,7 @@
   "scripts": {
     "build": "next build",
     "dev": "next",
-    "now-build": "next build",
-    "start": "next start"
+    "now-build": "next build"
   },
   "dependencies": {
     "next": "^8.0.0-canary.2",

--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -1,6 +1,9 @@
 {
   "scripts": {
-    "now-build": "next build"
+    "build": "next build",
+    "dev": "next",
+    "now-build": "next build",
+    "start": "next start"
   },
   "dependencies": {
     "next": "^8.0.0-canary.2",


### PR DESCRIPTION
### Overview

When running `now init` and selecting `nextjs`, it does not give you the same scripts as the [Next.js Setup docs](https://nextjs.org/docs/).

### Solution 

Apply the same scripts to the template. 

```json
"scripts": {
  "now-build": "next build",
  "dev": "next",
  "now-build": "next build",
  "start": "next start"
}
```