### PR TITLE
Update `nodejs-express` example to use `@now/node` builder

### DIFF
--- a/nodejs-express/about/index.js
+++ b/nodejs-express/about/index.js
@@ -1,0 +1,10 @@
+const express = require('express')
+const app = express()
+
+app.get('*', (req, res) => {
+    res.write('<h1><marquee direction=left>Hello from Express path `/about` on Now 2.0!</marquee></h1>')
+    res.write('<h2>Go to <a href="/">/</a></h2>')
+    res.end()
+})
+
+module.exports = app

--- a/nodejs-express/index.js
+++ b/nodejs-express/index.js
@@ -1,15 +1,9 @@
 const express = require('express')
-
-const port = process.env.PORT || 3000
 const app = express()
 
-app.get('/', (req, res) => {
-    res.send('<h1><marquee direction=right>Hello from Express path / on Now 2.0!</marquee></h1>')
-    res.end()
-})
-
-app.get('/about', (req, res) => {
-    res.send('<h1><marquee direction=left>Hello from Express path /about on Now 2.0!</marquee></h1>')
+app.get('*', (req, res) => {
+    res.write('<h1><marquee direction=right>Hello from Express path `/` on Now 2.0!</marquee></h1>')
+    res.write('<h2>Go to <a href="/about">/about</a></h2>')
     res.end()
 })
 

--- a/nodejs-express/index.js
+++ b/nodejs-express/index.js
@@ -13,7 +13,4 @@ app.get('/about', (req, res) => {
     res.end()
 })
 
-app.listen(port, err => {
-    if (err) throw err
-    console.log(`> Ready On Server http://localhost:${port}`)
-})
+module.exports = app

--- a/nodejs-express/now.json
+++ b/nodejs-express/now.json
@@ -2,9 +2,6 @@
     "version": 2,
     "name": "nodejs-express",
     "builds": [
-        { "src": "index.js", "use": "@now/node" }
-    ],
-    "routes": [
-        { "src": "/(.*)", "dest": "index.js" }
+        { "src": "**/*.js", "use": "@now/node" }
     ]
 }

--- a/nodejs-express/now.json
+++ b/nodejs-express/now.json
@@ -2,7 +2,7 @@
     "version": 2,
     "name": "nodejs-express",
     "builds": [
-        { "src": "index.js", "use": "@now/node-server" }
+        { "src": "index.js", "use": "@now/node" }
     ],
     "routes": [
         { "src": "/(.*)", "dest": "index.js" }

--- a/now.json
+++ b/now.json
@@ -10,7 +10,6 @@
         { "src": "create-react-app/package.json", "use": "@now/static-build" },
         { "src": "static/**", "use": "@now/static" },
         { "src": "nextjs/next.config.js", "use": "@now/next" },
-        { "src": "nextjs-express/**/*.js", "use": "@now/node" },
         { "src": "nextjs-static/package.json", "use": "@now/static-build" },
         { "src": "html-minifier/index.html", "use": "@now/html-minifier" },
         { "src": "mdx-deck/deck.mdx", "use": "@now/mdx-deck" },
@@ -19,6 +18,7 @@
         { "src": "nodejs-hapi/index.js", "use": "@now/node-server" },
         { "src": "nodejs-koa/index.js", "use": "@now/node" },
         { "src": "nodejs-coffee/app.js", "use": "@now/node" },
+        { "src": "nodejs-express/**/*.js", "use": "@now/node" },
         { "src": "gatsby/package.json", "use": "@now/static-build", "config": {"distDir": "public"} },
         { "src": "docz/package.json", "use": "@now/static-build" },
         { "src": "typescript/src/**/*.ts", "use": "@now/node@canary" }

--- a/now.json
+++ b/now.json
@@ -10,6 +10,7 @@
         { "src": "create-react-app/package.json", "use": "@now/static-build" },
         { "src": "static/**", "use": "@now/static" },
         { "src": "nextjs/next.config.js", "use": "@now/next" },
+        { "src": "nextjs-express/**/*.js", "use": "@now/node" },
         { "src": "nextjs-static/package.json", "use": "@now/static-build" },
         { "src": "html-minifier/index.html", "use": "@now/html-minifier" },
         { "src": "mdx-deck/deck.mdx", "use": "@now/mdx-deck" },


### PR DESCRIPTION
Because express returns the HTTP handler as the `app` object,
we can use the `@now/node` builder and directly export the `app`
object. This is how it is done in the Express + Now 2.0 blog post.