### PR TITLE
[nodejs-express] Bring README's `now.json` inline with source code of example

### DIFF
--- a/nodejs-express/README.md
+++ b/nodejs-express/README.md
@@ -29,7 +29,7 @@ We will also define a name for our project (optional).
     "version": 2,
     "name": "nodejs-express",
     "builds": [
-        { "src": "index.js", "use": "@now/node-server" }
+        { "src": "index.js", "use": "@now/node" }
     ],
     "routes": [
         { "src": "/(.*)", "dest": "index.js" }


### PR DESCRIPTION
The `now.json` was updated but the README was not.