### PR TITLE
Remove unnecessary circumflexes

### DIFF
--- a/create-react-app/now.json
+++ b/create-react-app/now.json
@@ -5,12 +5,12 @@
     {"src": "package.json", "use": "@now/static-build", "config": {"distDir": "build"}}
   ],
   "routes": [
-    {"src": "^/static/(.*)", "headers": {"cache-control": "s-maxage=31536000,immutable"}, "dest": "/static/$1"},
-    {"src": "^/favicon.ico", "dest": "/favicon.ico"},
-    {"src": "^/asset-manifest.json", "dest": "/asset-manifest.json"},
-    {"src": "^/manifest.json", "dest": "/manifest.json"},
-    {"src": "^/precache-manifest.(.*)", "dest": "/precache-manifest.$1"},
-    {"src": "^/service-worker.js", "headers": {"cache-control": "s-maxage=0"}, "dest": "/service-worker.js"},
-    {"src": "^/(.*)", "headers": {"cache-control": "s-maxage=0"}, "dest": "/index.html"}
+    {"src": "/static/(.*)", "headers": {"cache-control": "s-maxage=31536000,immutable"}, "dest": "/static/$1"},
+    {"src": "/favicon.ico", "dest": "/favicon.ico"},
+    {"src": "/asset-manifest.json", "dest": "/asset-manifest.json"},
+    {"src": "/manifest.json", "dest": "/manifest.json"},
+    {"src": "/precache-manifest.(.*)", "dest": "/precache-manifest.$1"},
+    {"src": "/service-worker.js", "headers": {"cache-control": "s-maxage=0"}, "dest": "/service-worker.js"},
+    {"src": "/(.*)", "headers": {"cache-control": "s-maxage=0"}, "dest": "/index.html"}
   ]
 }

--- a/create-react-app/now.json
+++ b/create-react-app/now.json
@@ -14,3 +14,4 @@
     {"src": "/(.*)", "headers": {"cache-control": "s-maxage=0"}, "dest": "/index.html"}
   ]
 }
+


### PR DESCRIPTION
According to the note at https://zeit.co/docs/v2/deployments/routes/#src:

> Both `^`, asserting the start of the path string, and `$`, asserting the end of the path string, are implied and are not necessary to write.