### PR TITLE
Add contact email to contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,17 @@
 # Contributing
 
-When contributing to this repository, make sure your example fits the purpose of the repository. 
-When in doubt, create an issue to discuss the change you wish to make. 
+When contributing to this repository, make sure your example fits the purpose of the repository.
+When in doubt, create an issue to discuss the change you wish to make.
 
 Please note we have a code of conduct, please follow it in all your interactions with the project.
 
 ## General Guidelines
 
 1. Make sure your example is deployable and works perfectly.
-2. A good `README.md` is the best "welcome mat" for your example. This repository has many examples, 
-   it is advised to copy & paste a `README.md` from another example and adapt to your contribution, 
+2. A good `README.md` is the best "welcome mat" for your example. This repository has many examples,
+   it is advised to copy & paste a `README.md` from another example and adapt to your contribution,
    for better navigation across examples.
-3. `now.json` should always be present. Developers expect the code to be as ready as possible, 
+3. `now.json` should always be present. Developers expect the code to be as ready as possible,
    which means having a correct `now.json` is expected.
 
 ## Code of Conduct
@@ -30,21 +30,21 @@ orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
   address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ### Our Responsibilities
@@ -71,7 +71,7 @@ further defined and clarified by project maintainers.
 ### Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+reported by contacting the project team at [team@zeit.co](mailto:team@zeit.co). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
Previously left as the template default, now people can get in touch easier if they have any problems :rocket: 