### PR TITLE
Change canary examples to stable

### DIFF
--- a/nodejs-koa-ts/now.json
+++ b/nodejs-koa-ts/now.json
@@ -1,9 +1,9 @@
 {
   "version": 2,
   "builds": [
-    { "src": "src/routes/first.ts", "use": "@now/node@canary" },
-    { "src": "src/routes/second.ts", "use": "@now/node@canary" },
-    { "src": "src/routes/default.ts", "use": "@now/node@canary" }
+    { "src": "src/routes/first.ts", "use": "@now/node" },
+    { "src": "src/routes/second.ts", "use": "@now/node" },
+    { "src": "src/routes/default.ts", "use": "@now/node" }
   ],
   "routes": [
     { "src": "/first", "dest": "src/routes/first.ts" },

--- a/now.json
+++ b/now.json
@@ -25,7 +25,7 @@
     { "src": "nodejs-micro/index.js", "use":  "now-micro" },
     { "src": "gatsby/package.json", "use": "@now/static-build", "config": { "distDir": "public" } },
     { "src": "docz/package.json", "use": "@now/static-build" },
-    { "src": "typescript/src/**/*.ts", "use": "@now/node@canary" },
+    { "src": "typescript/src/**/*.ts", "use": "@now/node" },
     {
       "src": "zola/build.sh",
       "use": "@now/static-build",


### PR DESCRIPTION
Thanks to @TooTallNate for publishing stable, we don't need to use canary builders for examples any longer.