### PR TITLE
Add "quick start" to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/zeit)
 
-## Quick Start
-
 To set up any of these examples as your own project, [install Now](https://zeit.co/docs/v2/getting-started/installation) and use the following command in your terminal.
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/zeit)
 
+## Quick Start
+
+```
+npm install -g now    # install the Now CLI
+now init              # initialize a new project from an example
+```
+
 ---
 
 ### Programming Languages

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 
 ## Quick Start
 
+To set up any of these examples as your own project, [install Now](https://zeit.co/docs/v2/getting-started/installation) and use the following command in your terminal.
+
 ```sh
-npm install -g now    # install Now CLI
-now init              # create a new project from an example
+now init <example>    # Create a new project from a specific <example>
+now init              # Pick an example in the CLI
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ## Quick Start
 
-```
-npm install -g now    # install the Now CLI
-now init              # initialize a new project from an example
+```sh
+npm install -g now    # install Now CLI
+now init              # create a new project from an example
 ```
 
 ---


### PR DESCRIPTION
This adds a "quick start" section to the readme.

I imagine many people coming to this repo have the Now CLI but might not know about `now init`.