### PR TITLE
Switch apollo from server to function

### DIFF
--- a/apollo/README.md
+++ b/apollo/README.md
@@ -9,7 +9,7 @@ This Apollo Server example features the [`now.json` configuration file](https://
 ```json
 {
   "version": 2,
-  "builds": [{ "src": "index.js", "use": "@now/node-server" }],
+  "builds": [{ "src": "index.js", "use": "@now/node" }],
   "routes": [{ "src": "/.*", "dest": "index.js" }]
 }
 ```
@@ -19,7 +19,7 @@ _now.json_
 - The [`routes` property](/docs/v2/deployments/configuration#routes) allows Now to route your deployment either by using a source and destination, or by way of a source, status, and headers.
 - The [`builds` property](https://zeit.co/docs/v2/deployments/builds) allows Now to use a [builder](https://zeit.co/docs/v2/deployments/builders/overview/) with a specific source target.
 
-The `@now/node-server` [builder](https://zeit.co/docs/v2/deployments/builders/overview) enables a Node.js server deployment.
+The `@now/node` [builder](https://zeit.co/docs/v2/deployments/builders/overview) enables a Node.js function.
 
 Deploy the app with Now.
 

--- a/apollo/index.js
+++ b/apollo/index.js
@@ -1,4 +1,5 @@
-const { ApolloServer, gql } = require('apollo-server');
+const express = require('express');
+const { ApolloServer, gql } = require('apollo-server-express');
 
 const books = [
   { id: 1, title: 'The Trials of Brother Jero', rating: 8, authorId: 1 },
@@ -77,6 +78,7 @@ const server = new ApolloServer({
   playground: true,
 });
 
-server.listen().then(({ url }) => {
-  console.log(`🚀 Server ready at ${url}`);
-});
+const app = express();
+server.applyMiddleware({ app, path: '*' });
+
+module.exports = app;

--- a/apollo/now.json
+++ b/apollo/now.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "builds": [
-    { "src": "index.js", "use": "@now/node-server" }
+    { "src": "index.js", "use": "@now/node" }
   ],
   "routes": [
     { "src": "/.*", "dest": "index.js" }

--- a/apollo/package.json
+++ b/apollo/package.json
@@ -9,8 +9,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "apollo-server": "^2.4.8",
+    "apollo-server-express": "^2.4.8",
+    "express": "^4.16.4",
     "graphql": "^14.1.1"
   }
 }
-


### PR DESCRIPTION
`node-server` as per the docs is a stop gap to 'to ease the upgrade process to Now 2.0' and recommend upgrading to the node builder:

<img width="703" alt="Screen Shot 2019-04-11 at 12 10 49 PM" src="https://user-images.githubusercontent.com/700617/55973128-ecb6fe00-5c52-11e9-896e-0f5ce55e6077.png">

This example uses [`apollo-server-express`](https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-express) to make the switch. I looked into [`apollo-server-lambda`](https://github.com/apollographql/apollo-server/tree/master/packages/apollo-server-lambda) but couldn't find a way to have the function signature conform to the export that `now` is expecting. Express however provides a quick way to piggy back on the other examples in this repo.

Another option is to make this a separate folder such as `apollo-lambda` or switching the current one to `apollo-server`

cc @unicodeveloper @DennisKo 