### PR TITLE
[nodejs-koa-ts] Update to work with `now dev`

### DIFF
--- a/nodejs-koa-ts/src/routes/default.ts
+++ b/nodejs-koa-ts/src/routes/default.ts
@@ -5,12 +5,13 @@ import { createApp } from "../common";
 
 async function main(ctx: Context, next: Function) {
   const { host } = ctx.headers;
+  const proto = ctx.headers['x-forwarded-proto'];
 
   ctx.status = 200;
   ctx.body = {
     description: 'Hello! This server supports multiple routes.',
-    first: `https://${host}/first`,
-    second: `https://${host}/second`
+    first: `${proto}://${host}/first`,
+    second: `${proto}://${host}/second`
   }
 }
 


### PR DESCRIPTION
Considering the `x-forwarded-proto` HTTP header instead of hard-coding `https` for the proto.

Fixes https://github.com/zeit/now-cli/issues/2158.