### PR TITLE
[monorepo] Update to use `x-forwarded-proto` and `x-forwarded-host` HTTP headers

### DIFF
--- a/monorepo/www/pages/index.js
+++ b/monorepo/www/pages/index.js
@@ -169,8 +169,9 @@ const Page = ({nows}) => <div className="container">
   </div>
 
 Page.getInitialProps = async ({req}) => {
-  const protocol = process.env.NOW_REGION === 'dev1' ? 'http' : 'https';
-  const baseUrl = `${protocol}://${req.headers.host}/api`
+  const protocol = req.headers['x-forwarded-proto']
+  const host = req.headers['x-forwarded-host'] || req.headers.host
+  const baseUrl = `${protocol}://${host}/api`
   const nows = await Promise.all(langs.map(async ({name, path, ext}) => {
     const now = await (await fetch(`${baseUrl}/${path}`)).text()
     return {name, path, now, ext}


### PR DESCRIPTION
This makes it work properly with `now dev` when it's running `next dev` instead of using a lambda.