### PR TITLE
[docz] Add `now-dev` package.json script

### DIFF
--- a/docz/package.json
+++ b/docz/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "docz dev",
     "build": "docz build",
-    "now-build": "yarn build",
+    "now-build": "docz build",
     "now-dev": "docz dev --port $PORT"
   },
   "devDependencies": {

--- a/docz/package.json
+++ b/docz/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "docz dev",
     "build": "docz build",
-    "now-build": "yarn build"
+    "now-build": "yarn build",
+    "now-dev": "docz dev --port $PORT"
   },
   "devDependencies": {
     "docz": "^0.13.7",


### PR DESCRIPTION
For use with `now dev`. See https://github.com/zeit/now-builders/pull/418.