### PR TITLE
Ignore `yarn-error.log` files from git repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ node_modules
 .bundle
 vendor
 target
+yarn-error.log
 
 .DS_Store


### PR DESCRIPTION
These should never be committed to the repo, so added to `.gitignore`.