### PR TITLE
Update nextjs-news to use `now dev`

### DIFF
--- a/nextjs-news/package.json
+++ b/nextjs-news/package.json
@@ -11,7 +11,7 @@
     "url-parse": "^1.4.4"
   },
   "scripts": {
-    "dev": "next",
+    "dev": "now dev",
     "build": "next build",
     "start": "next start",
     "now-build": "next build"


### PR DESCRIPTION
Updated the alias to use `now dev` so that `nom run dev` runs the app locally, as described in the blog post at https://zeit.co/blog/now-dev

(Currently, by using `next` the Next.js app runs, but the serverless function is not exposed.)