### PR TITLE
Remove redundant .nowignore entries

### DIFF
--- a/nextjs-news/.nowignore
+++ b/nextjs-news/.nowignore
@@ -1,5 +1,2 @@
-.gitignore
 .next
-.git
 .cache
-node_modules


### PR DESCRIPTION
The removed items are already ignored by default by the now CLI, see: https://github.com/zeit/docs/issues/767