### PR TITLE
Fix charge.js typo and .nowignore

### DIFF
--- a/charge/.nowignore
+++ b/charge/.nowignore
@@ -1,4 +1,3 @@
 README.md
-node_modules
 dist
 tmp

--- a/charge/README.md
+++ b/charge/README.md
@@ -1,6 +1,6 @@
 # Charge.js Example
 
-This directory is a brief example of a [Charge.js](https://charge.js.org/) site using the [@now/static-build](https://zeit.co/docs/v2/deployments/official-builders/static-build-now-static-build) builder.
+This directory is a brief example of a [Charge.js](https://charge.js.org/) site using the [@now/static-build](https://zeit.co/docs/v2/deployments/official-builders/static-build-now-static-build) Builder.
 
 ## Initializing this Example
 
@@ -14,7 +14,7 @@ $ now init charge
 
 The example consists of one source directory, `/source`, which contains an index and layout component. `/source` also includes a `/pages` directory where `.mdx` files are stored. This file structure is very basic as Charge focuses on simplicity, however, you are free to use whatever file structure suits your needs best.
 
-The example also includes a `now.json` file, this is used to configure your build when deploying to Now. The `package.json` has seen some minor changes with the addition of scrips from the Charge.js [documentation](https://charge.js.org/usage) along with a `now-build` script used by Now in deployment.
+The example also includes a `now.json` file, this is used to configure your build when deploying to Now. The `package.json` has seen some minor changes with the addition of scripts from the Charge.js [documentation](https://charge.js.org/usage) along with a `now-build` script used by Now in deployment.
 
 ## Resources
 

--- a/nextjs-mysql/.gitignore
+++ b/nextjs-mysql/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.env


### PR DESCRIPTION
This PR fixes a typo in the Charge.js README.md file and removes `node_modules` from `.nowignore` files as it is ignored by default.