### PR TITLE
Increase maxLambdaSize for python-django

### DIFF
--- a/now.json
+++ b/now.json
@@ -41,7 +41,7 @@
     {
       "src": "python-django/app.py",
       "use": "@now/python",
-      "config": { "maxLambdaSize": "15mb" }
+      "config": { "maxLambdaSize": "25mb" }
     },
     { "src": "vue/package.json", "use": "@now/static-build" },
     {

--- a/python-django/now.json
+++ b/python-django/now.json
@@ -3,7 +3,11 @@
   "version": 2,
   "public": true,
   "builds": [
-    { "src": "app.py", "use": "@now/python", "config": { "maxLambdaSize": "15mb" } },
+    {
+      "src": "app.py",
+      "use": "@now/python",
+      "config": { "maxLambdaSize": "25mb" }
+    },
     { "src": "css/**", "use": "@now/static" }
   ],
   "routes": [


### PR DESCRIPTION
This PR increases the `maxLambdaSize` for the Python-Django example.