### PR TITLE
Remove @now/mdx-deck link

### DIFF
--- a/mdx-deck-advanced/README.md
+++ b/mdx-deck-advanced/README.md
@@ -18,8 +18,6 @@ For this example we will be using our newest version [Now 2.0](https://zeit.co/d
 
 By adding the `version` key to the `now.json` file, we can specify which Now Platform version to use.
 
-We also need to define how the project will be built. In this case, we will use the [@now/mdx-deck Builder](https://zeit.co/docs/v2/deployments/official-builders/mdx-deck-now-mdx-deck/).
-
 [Builders](https://zeit.co/docs/v2/deployments/builders/overview/) are modules that take a deployment's source and return an output, consisting of [either static files or dynamic Lambdas](https://zeit.co/docs/v2/deployments/builds/#sources-and-outputs).
 
 In this case we are going to use `@now/static-build` to build and deploy our static application selecting the `package.json` as our entry point. We will also define a name for our project (optional).


### PR DESCRIPTION
This example doesnt use `@now/mdx-deck` so I removed it.

Instead it uses `@now/static-build`.