### PR TITLE
[nodejs-pdfkit] Don't use res.send(Stream)

### DIFF
--- a/nodejs-pdfkit/index.js
+++ b/nodejs-pdfkit/index.js
@@ -21,6 +21,6 @@ module.exports = (req, res) => {
   doc
     .fillColor(text ? "#50E3C2" : "#FF0080")
     .text(text || "No `text` query!", 50, 130);
-  res.status(200).send(doc);
+  doc.pipe(res);
   doc.end();
 };


### PR DESCRIPTION
We are going to remove being able to send a `Stream` with `res.send()` (expressjs does not support it).

As a consequence, I removed it from the `nodejs-pdfkit` example and replaced it by a simple `pipe`.