### PR TITLE
Fix broken build for Vue

### DIFF
--- a/vue/vue.config.js
+++ b/vue/vue.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    productionSourceMap: false
+}


### PR DESCRIPTION
The builder for static sites generate an error related to sourcemaps (even locally), by adding this config productionSourceMap to false the build run successfully and the project is fully deployed.