### PR TITLE
Add private:true to every `package.json`

### DIFF
--- a/apollo/package.json
+++ b/apollo/package.json
@@ -1,6 +1,7 @@
 {
   "name": "improved-apollo-example",
   "version": "1.0.0",
+  "private": true,
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/create-elm-app/package.json
+++ b/create-elm-app/package.json
@@ -1,6 +1,7 @@
 {
   "name": "elm-example-app",
   "version": "1.0.0",
+  "private": true,
   "description": "Elm example app",
   "scripts": {
     "start": "elm-app start",

--- a/express/package.json
+++ b/express/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "dependencies": {
     "express": "^4.16.4",
     "helmet": "^3.18.0",

--- a/gatsby/package.json
+++ b/gatsby/package.json
@@ -1,6 +1,7 @@
 {
   "name": "gatsby-starter-default",
   "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "gatsby": "^2.0.19",
     "gatsby-image": "^2.0.15",

--- a/monorepo/www/package.json
+++ b/monorepo/www/package.json
@@ -1,6 +1,7 @@
 {
   "name": "monorepo",
   "license": "MIT",
+  "private": true,
   "dependencies": {
     "isomorphic-unfetch": "3.0.0",
     "next": "^8.0.0-canary.2",

--- a/nextjs-mysql/package.json
+++ b/nextjs-mysql/package.json
@@ -2,8 +2,7 @@
   "name": "serverless-mysql",
   "version": "1.0.0",
   "main": "index.js",
-  "repository": "git@github.com:msweeneydev/serverless-mysql.git",
-  "author": "msweeneydev <mail@msweeneydev.com>",
+  "private": true,
   "license": "MIT",
   "dependencies": {
     "isomorphic-unfetch": "^3.0.0",

--- a/nextjs-news/package.json
+++ b/nextjs-news/package.json
@@ -1,6 +1,7 @@
 {
   "name": "next-news",
   "license": "MIT",
+  "private": true,
   "dependencies": {
     "isomorphic-fetch": "^2.2.1",
     "ms": "^2.1.1",

--- a/nextjs-nodejs-mongodb/package.json
+++ b/nextjs-nodejs-mongodb/package.json
@@ -1,9 +1,8 @@
 {
   "name": "github-guestbook",
   "version": "1.0.0",
+  "private": true,
   "main": "index.js",
-  "repository": "git@github.com:msweeneydev/github-guestbook.git",
-  "author": "msweeneydev <mail@msweeneydev.com>",
   "license": "MIT",
   "dependencies": {
     "date-fns": "^1.30.1",

--- a/nextjs-static/package.json
+++ b/nextjs-static/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "scripts": {
     "now-build": "next build && next export -o dist",
     "now-dev": "next -p $PORT"

--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "scripts": {
     "build": "next build",
     "dev": "next",

--- a/node-server/package.json
+++ b/node-server/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "dependencies": {
     "moment": "^2.24.0"
   }

--- a/nodejs-canvas-partyparrot/package.json
+++ b/nodejs-canvas-partyparrot/package.json
@@ -1,16 +1,13 @@
 {
   "name": "ppaas",
   "version": "1.0.0",
+  "private": true,
   "description": "Party Parrot as a Service",
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": [
-    "partyparrot"
-  ],
-  "author": "flguillemette",
   "license": "ISC",
   "dependencies": {
     "canvas": "^2.2.0",

--- a/nodejs-hapi/package.json
+++ b/nodejs-hapi/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "dependencies": {
     "hapi": "^17.7.0"
   }

--- a/nodejs-koa-ts/package.json
+++ b/nodejs-koa-ts/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "dependencies": {
     "koa": "^2.6.2",
     "koa-bodyparser": "^4.2.1",

--- a/nodejs-koa/package.json
+++ b/nodejs-koa/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "dependencies": {
     "koa": "^2.6.2"
   }

--- a/nodejs-micro/package.json
+++ b/nodejs-micro/package.json
@@ -1,5 +1,6 @@
 {
   "name": "nodejs-micro",
+  "private": true,
   "dependencies": {
     "micro": "^9.3.5-canary.1"
   }

--- a/nodejs-ms-graph-security-api/site/package.json
+++ b/nodejs-ms-graph-security-api/site/package.json
@@ -1,9 +1,9 @@
 {
+  "private": true,
   "scripts": {
     "now-build": "next build",
     "dev": "next dev"
   },
-  "author": "Olli Vanhoja",
   "license": "MIT",
   "dependencies": {
     "async-retry": "1.2.3",

--- a/nodejs-pdfkit/package.json
+++ b/nodejs-pdfkit/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "dependencies": {
     "pdfkit": "^0.8.3"
   }

--- a/nodejs-ts/package.json
+++ b/nodejs-ts/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "dependencies": {
     "moment": "^2.24.0"
   },

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "dependencies": {
     "moment": "^2.24.0"
   }

--- a/slack-eval/package.json
+++ b/slack-eval/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "dependencies": {
     "micro": "^9.3.3",
     "node-fetch": "^2.3.0",

--- a/vanilla-json-api/package.json
+++ b/vanilla-json-api/package.json
@@ -1,6 +1,7 @@
 {
   "name": "json-api-test",
   "version": "0.0.1",
+  "private": true,
   "dependencies": {
     "faker": "^4.1.0",
     "json-server": "^0.14.2",

--- a/vue-ssr/package.json
+++ b/vue-ssr/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "dependencies": {
     "vue": "^2.5.17",
     "vue-server-renderer": "^2.5.17"


### PR DESCRIPTION
There is some inconsistency between each example `package.json`

This is one step to bring them closer into alignment.

In particular, `private: true` will make sure that the user doesn't accidentally publish their code to npm. It will also prevent yarn from displaying "warning: no license" in the case there is no license defined.

We might want to consolidate the license on each of these examples as well in a future PR (I see some MIT, ISC, etc).