### PR TITLE
Replace `@now/node-server` with `@now/node`

### DIFF
--- a/node-server/README.md
+++ b/node-server/README.md
@@ -4,7 +4,7 @@
 
 This example shows a pre-setup project including:
 
-- An `api` directory, containing a single endpoint that retrieves the current time with Node.js built with the [@now/node-server Builder](https://zeit.co/docs/v2/deployments/official-builders/node-js-server-now-node-server/).
+- An `api` directory, containing a single endpoint that retrieves the current time with Node.js built with the [@now/node Builder](https://zeit.co/docs/v2/deployments/official-builders/node-js-now-node).
 - A `www` directory, containing static files such as `index.html` and `style.css` that show a frontend with information from the API.
 
 ## Get Started with This Project
@@ -70,7 +70,7 @@ This example contains a `now.json` file which instructs Now how to treat this pr
   "name": "my-node-server-project",
   "builds": [
     { "src": "www/**/*", "use": "@now/static" },
-    { "src": "api/**/*.js", "use": "@now/node-server" }
+    { "src": "api/**/*.js", "use": "@now/node" }
   ],
   "routes": [{ "src": "/", "dest": "www/index.html" }]
 }
@@ -80,7 +80,7 @@ The above instructs Now with:
 
 - The [`version` property](https://zeit.co/docs/v2/deployments/configuration#version), specifying the latest Now 2.0 Platform version.
 - The [`name` property](https://zeit.co/docs/v2/deployments/configuration#name), setting the name for the deployment.
-- The [`builds` property](https://zeit.co/docs/v2/deployments/configuration#builds), allowing Now to use [the @now/node-server Builder](https://zeit.co/docs/v2/deployments/official-builders/node-js-server-now-node-server/) with a specific source target.
+- The [`builds` property](https://zeit.co/docs/v2/deployments/configuration#builds), allowing Now to use [the @now/node Builder](https://zeit.co/docs/v2/deployments/official-builders/node-js-now-node) with a specific source target.
 - The [`routes` property](https://zeit.co/docs/v2/deployments/configuration#routes), instructing Now to route the user to the `www/index.html` file when requesting the root path.
 
 For more information on configuring Now, see the [Configuration documentation](https://zeit.co/docs/v2/deployments/configuration).
@@ -89,5 +89,5 @@ For more information on configuring Now, see the [Configuration documentation](h
 
 Learn more about the ZEIT Now platform from [our documentation](https://zeit.co/docs), including:
 
-- [More information on deploying Node-Server projects](https://zeit.co/docs/v2/deployments/official-builders/node-js-server-now-node-server/) and some technical details.
+- [More information on deploying Node projects](https://zeit.co/docs/v2/deployments/official-builders/node-js-now-node) and some technical details.
 - [More information on the platform itself](https://zeit.co/docs), including [domains and aliasing](https://zeit.co/docs/v2/domains-and-aliases/introduction/) and [local development](https://zeit.co/docs/v2/development/basics/).

--- a/node-server/api/date.js
+++ b/node-server/api/date.js
@@ -7,4 +7,4 @@ const server = http.createServer((req, res) => {
   res.end(currentTime);
 });
 
-server.listen();
+module.exports = server;

--- a/node-server/now.json
+++ b/node-server/now.json
@@ -3,7 +3,7 @@
   "name": "my-node-server-project",
   "builds": [
     { "src": "www/**/*", "use": "@now/static" },
-    { "src": "api/**/*.js", "use": "@now/node-server" }
+    { "src": "api/**/*.js", "use": "@now/node" }
   ],
   "routes": [{ "src": "/", "dest": "www/index.html" }]
 }

--- a/nodejs-canvas-partyparrot/README.md
+++ b/nodejs-canvas-partyparrot/README.md
@@ -9,20 +9,24 @@ This example is basically a fork of [PPaaS](https://github.com/francoislg/PPaaS)
 
 The new APIs works perfectly with just a few small changes in `ParrotFrameHandler.js`.
 
-## Config `@now/node-server`
+## Config `@now/node`
 First we need to [increase the max lambda size](https://zeit.co/blog/customizable-lambda-sizes) to `40mb` cause it exceeds the default limit.
 
-Also, PPaaS has "baseparrots" images which will be read at runtime. So these assets cannot be compiled and bundled by [ncc](https://github.com/zeit/ncc). We need to disable the `bundle` option so all files will be copied to the right place.
+Also, PPaaS has "baseparrots" images which will be read at runtime. So these assets cannot be compiled and bundled by [ncc](https://github.com/zeit/ncc). We need to use the `includeFiles` option so that dynamic files will be included.
 
-In summary, the `@now/node-server` config looks like this:
+In summary, the `@now/node` config looks like this:
 
 ```json
 {
   "src": "index.js",
-  "use": "@now/node-server",
+  "use": "@now/node",
   "config": {
-    "maxLambdaSize": "40mb",
-    "bundle": false
+    "maxLambdaSize": "28mb",
+    "includeFiles": [
+      "baseparrots/**",
+      "baseparrots-white/**",
+      "src/parrotconfigs/**"
+    ]
   }
 }
 ```

--- a/nodejs-canvas-partyparrot/api.js
+++ b/nodejs-canvas-partyparrot/api.js
@@ -3,7 +3,6 @@ const ParrotOptionsValidator = require("./src/ParrotOptionsValidator");
 const path = require("path");
 const fs = require('fs')
 const express = require("express");
-const request = require("request-promise");
 
 var app = express();
 
@@ -70,4 +69,4 @@ function constructParrot(res, queryParams) {
     }
 }
 
-app.listen(process.env.PORT || 8080);
+module.exports = app;

--- a/nodejs-canvas-partyparrot/now.json
+++ b/nodejs-canvas-partyparrot/now.json
@@ -5,19 +5,20 @@
         "src": "index.html",
         "use": "@now/static"
     }, {
-        "src": "index.js",
-        "use": "@now/node-server",
+        "src": "api.js",
+        "use": "@now/node",
         "config": {
-            "maxLambdaSize": "40mb",
-            "bundle": false
+            "maxLambdaSize": "28mb",
+            "includeFiles": [
+                "baseparrots/**",
+                "baseparrots-white/**",
+                "src/parrotconfigs/**"
+            ]
         }
     }],
     "routes": [{
-        "src": "/",
-        "dest": "index.html"
-    }, {
         "src": "/(.+)",
-        "dest": "index.js",
+        "dest": "api.js",
         "headers": {
             "cache-control": "public, max-age=31536000, immutable"
         }

--- a/nodejs-canvas-partyparrot/package.json
+++ b/nodejs-canvas-partyparrot/package.json
@@ -13,8 +13,6 @@
     "canvas": "^2.2.0",
     "express": "^4.14.0",
     "gifencoder": "^2.0.1",
-    "left-pad": "^1.1.3",
-    "request": "^2.79.0",
-    "request-promise": "^4.1.1"
+    "request": "^2.79.0"
   }
 }

--- a/nodejs-canvas-partyparrot/src/ImageFactory.js
+++ b/nodejs-canvas-partyparrot/src/ImageFactory.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-const config = require("./config");
 const Image = require("canvas").Image;
 const request = require("request").defaults({ encoding: null });
 

--- a/nodejs-canvas-partyparrot/src/ParrotConstructor.js
+++ b/nodejs-canvas-partyparrot/src/ParrotConstructor.js
@@ -3,7 +3,6 @@ const ParrotFramesReader = require("./ParrotFramesReader");
 const ParrotFrameHandler = require("./ParrotFrameHandler");
 const ParrotConfig = require("./ParrotConfig");
 const ImageFactory = require("./ImageFactory");
-const config = require("./config");
 
 function ParrotConstructor() {
     this.imageFactory = new ImageFactory();

--- a/nodejs-canvas-partyparrot/src/ParrotFrameHandler.js
+++ b/nodejs-canvas-partyparrot/src/ParrotFrameHandler.js
@@ -1,5 +1,4 @@
-const fs = require('fs');
-const { Canvas, Image, createCanvas } = require('canvas');
+const { createCanvas } = require('canvas');
 
 function ParrotFrameHandler(parrotConfig) {
     this.width = parrotConfig.getWidth();

--- a/nodejs-canvas-partyparrot/src/ParrotFramesReader.js
+++ b/nodejs-canvas-partyparrot/src/ParrotFramesReader.js
@@ -1,5 +1,4 @@
 const config = require("./config");
-const leftpad = require("left-pad")
 
 function ParrotFramesReader(parrotConfig, whiteVersion) {
     this.parrotConfig = parrotConfig;
@@ -10,7 +9,7 @@ ParrotFramesReader.prototype.getFrames = function() {
     let frames = [];
     let numberOfFrames = this.parrotConfig.getNumberOfFrames();
     for(var i = 1; i <= numberOfFrames; i++) {
-        frames.push(`${this.baseParrotsPath}/${this.parrotConfig.getParrotType()}/frame-${leftpad(i, 3, '0')}.png`);
+        frames.push(`${this.baseParrotsPath}/${this.parrotConfig.getParrotType()}/frame-${i.toString().padStart(3, '0')}.png`);
     }
     return frames;
 }

--- a/nodejs-hapi/index.js
+++ b/nodejs-hapi/index.js
@@ -1,9 +1,9 @@
-const Hapi = require('hapi')
+const Hapi = require('@hapi/hapi');
 
-const server = new Hapi.server({
-  host: 'localhost',
-  port: 3000
-})
+const server = Hapi.server({
+    port: 3000,
+    host: 'localhost'
+});
 
 server.route({
   method: 'GET',
@@ -11,4 +11,4 @@ server.route({
   handler: () => 'Hello from hapi.js!'
 })
 
-server.start()
+module.exports = server.listener;

--- a/nodejs-hapi/now.json
+++ b/nodejs-hapi/now.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "builds": [
-    { "src": "index.js", "use": "@now/node-server" }
+    { "src": "index.js", "use": "@now/node" }
   ],
   "routes": [
     { "src": "/(.*)", "dest": "/index.js" }

--- a/nodejs-hapi/package.json
+++ b/nodejs-hapi/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "hapi": "^17.7.0"
+    "@hapi/hapi": "18.3.1"
   }
 }

--- a/now.json
+++ b/now.json
@@ -3,7 +3,7 @@
   "name": "now-examples",
   "public": true,
   "builds": [
-    { "src": "apollo/index.js", "use": "@now/node-server" },
+    { "src": "apollo/index.js", "use": "@now/node" },
     { "src": "bash/*.sh", "use": "@now/bash" },
     { "src": "markdown/*.css", "use": "@now/static" },
     {
@@ -65,9 +65,9 @@
     { "src": "html-minifier/index.html", "use": "@now/html-minifier" },
     { "src": "mdx-deck/deck.mdx", "use": "@now/mdx-deck" },
     { "src": "node-server/static/**/*", "use": "@now/static" },
-    { "src": "node-server/api/**/*.js", "use": "@now/node-server" },
+    { "src": "node-server/api/**/*.js", "use": "@now/node" },
     { "src": "optipng/showcase.png", "use": "@now/optipng" },
-    { "src": "nodejs-hapi/index.js", "use": "@now/node-server" },
+    { "src": "nodejs-hapi/index.js", "use": "@now/node" },
     { "src": "nodejs-koa/index.js", "use": "@now/node" },
     {
       "src": "nodejs-coffee/app.coffee",


### PR DESCRIPTION
We want to discourage usage of the `@now/node-server` since it will become deprecated soon.

I changed all the examples that currently use `@now/node-server` to instead use `@now/node`.

We are planning to add `server.listen(3000)` support to `@now/node` however we don't want to encourage this usage. Instead, we think `module.exports = server` is best.

I also update `hapi` to the latest `@hapi/hapi` and remove unused dependencies from PPaaS.