### PR TITLE
[express] Remove api/ prefix from paths in ignore files 

### DIFF
--- a/express/.gitignore
+++ b/express/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+yarn.lock

--- a/express/.gitignore
+++ b/express/.gitignore
@@ -1,2 +1,1 @@
-api/node_modules
-api/yarn.lock
+node_modules/

--- a/express/.nowignore
+++ b/express/.nowignore
@@ -1,3 +1,2 @@
 README.md
-api/node_modules
-api/yarn.lock
+node_modules/


### PR DESCRIPTION
* Remove `api/` prefix from paths in `.gitignore` and `.nowignore`
* ~Remove `yarn.lock` from `.gitignore` and `.nowignore` as it should be in version control and is needed for deployment~