### PR TITLE
Add `now dev` support for puppeteer-screenshot

### DIFF
--- a/puppeteer-screenshot/chromium.js
+++ b/puppeteer-screenshot/chromium.js
@@ -1,12 +1,9 @@
-const chrome = require('chrome-aws-lambda');
 const puppeteer = require('puppeteer-core');
+const { getOptions } = require('./options');
 
 async function getScreenshot(url, type, quality, fullPage) {
-    const browser = await puppeteer.launch({
-        args: chrome.args,
-        executablePath: await chrome.executablePath,
-        headless: chrome.headless,
-    });
+    const options = await getOptions();
+    const browser = await puppeteer.launch(options);
 
     const page = await browser.newPage();
     await page.goto(url);

--- a/puppeteer-screenshot/options.js
+++ b/puppeteer-screenshot/options.js
@@ -1,0 +1,25 @@
+const chrome = require('chrome-aws-lambda');
+
+const isDev = process.env.NOW_REGION === 'dev1';
+
+const exePath = process.platform === 'win32'
+    ? 'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe'
+    : '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
+async function getOptions() {
+    if (isDev) {
+        return {
+            args: [],
+            executablePath: exePath,
+            headless: true
+        };
+    }
+    
+    return {
+        args: chrome.args,
+        executablePath: await chrome.executablePath,
+        headless: chrome.headless,
+    };
+}
+
+module.exports = { getOptions };


### PR DESCRIPTION
Fixes #361

This will use the local installed Google Chrome with `now dev` because the `chrome-aws-lambda` only works in a real Lambda due to native binaries.