### PR TITLE
Update ember build script

### DIFF
--- a/ember/README.md
+++ b/ember/README.md
@@ -7,7 +7,7 @@ This directory is a brief example of an [Ember](https://emberjs.com/) app that c
 To get started with Ember on Now, you can use the [Ember CLI](https://ember-cli.com/) to initialize the project:
 
 ```shell
-$ npx ember new ember-project
+$ npx ember-cli new ember-project
 ```
 
 ## Deploying this Example

--- a/ember/package.json
+++ b/ember/package.json
@@ -11,7 +11,7 @@
     "test": "tests"
   },
   "scripts": {
-    "build": "ember build -prod",
+    "build": "ember build",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
     "start": "ember serve",


### PR DESCRIPTION
This PR updates the Ember build script as the `-prod` flag is not compatible with the default example.