### PR TITLE
Add HyperApp Example

### DIFF
--- a/hyperapp/.editorconfig
+++ b/hyperapp/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.json]
+indent_size = 2
+
+[*.{diff,md}]
+trim_trailing_whitespace = false

--- a/hyperapp/.gitignore
+++ b/hyperapp/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+release
+yarn.lock

--- a/hyperapp/README.md
+++ b/hyperapp/README.md
@@ -1,0 +1,19 @@
+# HyperApp Example
+
+This directory is a brief example of a [HyperApp](https://github.com/jorgebucaran/hyperapp) app that can be deployed to ZEIT Now with zero configuration.
+
+## How we created this example
+
+To get started with HyperApp on Now, you can use the [Now CLI](https://zeit.co/download) to initialize the project:
+
+```shell
+$ now init hyperapp
+```
+
+## Deploying this Example
+
+Once initialized, you can deploy the HyperApp example with just a single command:
+
+```shell
+$ now
+```

--- a/hyperapp/package.json
+++ b/hyperapp/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "hyperapp-boilerplate",
+  "version": "0.0.4",
+  "description": "This is a sample/boilerplate project that shows how to create a production-ready hyperapp application.",
+  "scripts": {
+    "build": "taskr build release",
+    "start": "taskr watch",
+    "preserve": "npm run build",
+    "serve": "serve release -s -p 4000"
+  },
+  "main": "src/app.js",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/tzellman/hyperapp-boilerplate.git"
+  },
+  "author": "Tom Zellman <tzellman@gmail.com> (@tzellman)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/tzellman/hyperapp-boilerplate/issues"
+  },
+  "homepage": "https://github.com/tzellman/hyperapp-boilerplate#readme",
+  "devDependencies": {
+    "@taskr/clear": "^1.1.0",
+    "@taskr/concat": "^1.1.0",
+    "@taskr/esnext": "^1.1.0",
+    "@taskr/htmlmin": "^1.1.0",
+    "@taskr/postcss": "^1.1.2",
+    "@taskr/rev": "^1.1.0",
+    "@taskr/sass": "^1.1.0",
+    "@taskr/uglify": "^1.1.0",
+    "@taskr/watch": "^1.1.0",
+    "autoprefixer": "9.6.1",
+    "browser-sync": "2.26.7",
+    "fly-precache": "^2.1.0",
+    "fly-rollup": "^2.1.0",
+    "rollup": "^0.50.0",
+    "rollup-plugin-buble": "^0.16.0",
+    "rollup-plugin-commonjs": "^8.0.2",
+    "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-plugin-replace": "2.2.0",
+    "serve": "11.0.2",
+    "taskr": "^1.1.0"
+  },
+  "dependencies": {
+    "hyperapp": "1.2.10"
+  }
+}

--- a/hyperapp/src/actions/counter.js
+++ b/hyperapp/src/actions/counter.js
@@ -1,0 +1,6 @@
+const actions = {
+    add: () => (state) => ({ num: state.num + 1, clicks: state.clicks + 1 }),
+    sub: () => (state) => ({ num: state.num - 1, clicks: state.clicks + 1 })
+};
+
+export default actions;

--- a/hyperapp/src/app.js
+++ b/hyperapp/src/app.js
@@ -1,0 +1,7 @@
+import './service-worker-registration';
+import { app } from 'hyperapp';
+import actions from './actions/counter';
+import state from './states/counter';
+import view from './views/counter';
+
+app(state, actions, view, document.body);

--- a/hyperapp/src/index.html
+++ b/hyperapp/src/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1" />
+        <title>Hyperapp Boilerplate</title>
+        <link rel="stylesheet" type="text/css" href="./app.css" />
+    </head>
+
+    <body>
+        <script src="./app.js"></script>
+    </body>
+</html>

--- a/hyperapp/src/service-worker-registration.js
+++ b/hyperapp/src/service-worker-registration.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-env browser */
+'use strict';
+
+if ('serviceWorker' in navigator) {
+    // Delay registration until after the page has loaded, to ensure that our
+    // precaching requests don't degrade the first visit experience.
+    // See https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/registration
+    window.addEventListener('load', function () {
+        // Your service-worker.js *must* be located at the top-level directory relative to your site.
+        // It won't be able to control pages unless it's located at the same level or higher than them.
+        // *Don't* register service worker file in, e.g., a scripts/ sub-directory!
+        // See https://github.com/slightlyoff/ServiceWorker/issues/468
+        navigator.serviceWorker.register('service-worker.js').then(function (reg) {
+            // updatefound is fired if service-worker.js changes.
+            reg.onupdatefound = function () {
+                // The updatefound event implies that reg.installing is set; see
+                // https://w3c.github.io/ServiceWorker/#service-worker-registration-updatefound-event
+                var installingWorker = reg.installing;
+
+                installingWorker.onstatechange = function () {
+                    switch (installingWorker.state) {
+                        case 'installed':
+                            if (navigator.serviceWorker.controller) {
+                                // At this point, the old content will have been purged and the fresh content will
+                                // have been added to the cache.
+                                // It's the perfect time to display a "New content is available; please refresh."
+                                // message in the page's interface.
+                                console.log('New or updated content is available.');
+                            } else {
+                                // At this point, everything has been precached.
+                                // It's the perfect time to display a "Content is cached for offline use." message.
+                                console.log('Content is now available offline!');
+                            }
+                            break;
+
+                        case 'redundant':
+                            console.error('The installing service worker became redundant.');
+                            break;
+                    }
+                };
+            };
+        }).catch(function (e) {
+            console.error('Error during service worker registration:', e);
+        });
+    });
+}

--- a/hyperapp/src/states/counter.js
+++ b/hyperapp/src/states/counter.js
@@ -1,0 +1,6 @@
+const state = {
+    num: 0,
+    clicks: 0
+};
+
+export default state;

--- a/hyperapp/src/styles/_variables.scss
+++ b/hyperapp/src/styles/_variables.scss
@@ -1,0 +1,8 @@
+/* Variables */
+$color-heading: #111;
+$color-text: #444;
+$font-family: sans-serif;
+
+$color-add: mediumseagreen;
+$color-sub: mediumvioletred;
+$color-outline: darkturquoise;

--- a/hyperapp/src/styles/app.scss
+++ b/hyperapp/src/styles/app.scss
@@ -1,0 +1,60 @@
+@import "variables";
+
+/* Simple reset. */
+body,
+* {
+    box-sizing: border-box;
+    margin: 0;
+}
+
+body {
+    padding: 2rem;
+    color: $color-text;
+    font-family: $font-family;
+    font-size: 18px;
+}
+
+.counter {
+    text-align: center;
+
+    h1 {
+        color: $color-heading;
+    }
+
+    section > h1 {
+        padding: 1rem 0;
+    }
+
+    button {
+        border-color: black;
+        border-radius: 3px;
+        border-style: solid;
+        border-width: 1px;
+        width: 30px;
+        height: 30px;
+        outline-color: $color-outline;
+        cursor: pointer;
+
+        &.add {
+            background-color: $color-add;
+            font-size: 20px;
+            color: black;
+        }
+
+        &.sub {
+            background-color: $color-sub;
+            font-size: 20px;
+            color: black;
+
+            &:disabled {
+                background-color: lighten($color-sub, 50%);
+                cursor: not-allowed;
+            }
+        }
+    }
+
+    .line-break {
+        width: 100%;
+        margin: 30px 0;
+    }
+}

--- a/hyperapp/src/views/counter.js
+++ b/hyperapp/src/views/counter.js
@@ -1,0 +1,26 @@
+import { h } from 'hyperapp';
+
+const clickCount = clicks => {
+    return clicks > 0 ? <div>You clicked {clicks} time{clicks > 1 ? 's' : ''}</div> : '';
+};
+
+const Button = ({className, label, update, disabled}) => (
+    <button class={className} onclick={update} disabled={disabled ? disabled : false}>
+        {label}
+    </button>
+);
+
+const view = (state, actions) => (
+    <div class="counter">
+        <h1>Welcome to HyperApp!</h1>
+        <hr class="line-break"/>
+        <section>
+            {Button({className: 'add', label: '+', update: actions.add})}
+            <h1>{state.num}</h1>
+            {Button({className: 'sub', label: '-', update: actions.sub, disabled: state.num <= 0})}
+            {clickCount(state.clicks)}
+        </section>
+    </div>
+);
+
+export default view;

--- a/hyperapp/taskfile.js
+++ b/hyperapp/taskfile.js
@@ -1,0 +1,133 @@
+const browserSync = require('browser-sync');
+
+let isWatching = false;
+
+// some source/dest consts
+const target = 'dist';
+const releaseTarget = 'public';
+const src = {
+    js: 'src/**/*.js',
+    scss: 'src/styles/app.scss',
+    staticAssets: ['src/static/**/*.*', 'src/*.html'],
+    vendor: []
+};
+
+export async function clean(taskr) {
+    await taskr.clear([target, releaseTarget]);
+}
+
+export async function copyStaticAssets(taskr, o) {
+    await taskr.source(o.src || src.staticAssets).target(target);
+}
+
+export async function vendors(taskr) {
+    await taskr
+        .source(src.vendor)
+        .concat('vendor.js')
+        .target(`${target}`);
+}
+
+export async function js(taskr) {
+    await taskr
+        .source('src/app.js')
+        .rollup({
+            rollup: {
+                plugins: [
+                    require('rollup-plugin-buble')({ jsx: 'h' }),
+                    require('rollup-plugin-commonjs')(),
+                    require('rollup-plugin-replace')({
+                        'process.env.NODE_ENV': JSON.stringify(
+                            isWatching ? 'development' : 'production'
+                        )
+                    }),
+                    require('rollup-plugin-node-resolve')({
+                        browser: true,
+                        main: true
+                    })
+                ]
+            },
+            bundle: {
+                format: 'iife',
+                sourceMap: isWatching,
+                moduleName: 'window'
+            }
+        })
+        .target(`${target}`);
+}
+
+export async function styles(taskr) {
+    await taskr
+        .source(src.scss)
+        .sass({
+            outputStyle: 'compressed',
+            includePaths: []
+        })
+        .postcss({
+            plugins: [
+                require('autoprefixer')({ browsers: ['last 2 versions'] })
+            ]
+        })
+        .target(`${target}`);
+}
+
+export async function build(taskr) {
+    // TODO add linting
+    await taskr.serial([
+        'clean',
+        'copyStaticAssets',
+        'styles',
+        'js',
+        'vendors'
+    ]);
+}
+
+export async function release(taskr) {
+    await taskr
+        .source(`${target}/*.js`)
+        .uglify({
+            compress: {
+                conditionals: 1,
+                drop_console: 1,
+                comparisons: 1,
+                join_vars: 1,
+                booleans: 1,
+                loops: 1
+            }
+        })
+        .target(target);
+    await taskr
+        .source(`${target}/**/*`)
+        .rev({
+            ignores: ['.html', '.png', '.svg', '.ico', '.json', '.txt']
+        })
+        .revManifest({ dest: releaseTarget, trim: target })
+        .revReplace()
+        .target(releaseTarget);
+    await taskr
+        .source(`${releaseTarget}/*.html`)
+        .htmlmin()
+        .target(releaseTarget);
+    await taskr
+        .source(`${releaseTarget}/**/*.{js,css,html,png,jpg,gif}`)
+        .precache({ stripPrefix: `${releaseTarget}/` })
+        .target(releaseTarget);
+}
+
+export async function watch(taskr) {
+    isWatching = true;
+    await taskr.start('build');
+    await taskr.watch(src.js, ['js', 'reload']);
+    await taskr.watch(src.scss, ['styles', 'reload']);
+    await taskr.watch(src.staticAssets, ['copyStaticAssets', 'reload']);
+    // start server
+    browserSync({
+        server: target,
+        logPrefix: 'hyperapp',
+        port: process.env.PORT || 4000,
+        middleware: [require('connect-history-api-fallback')()]
+    });
+}
+
+export async function reload(taskr) {
+    isWatching && browserSync.reload();
+}

--- a/manifest.json
+++ b/manifest.json
@@ -138,6 +138,12 @@
     "description": "A Mithril app to get you up and running."
   },
   {
+    "example": "HyperApp",
+    "path": "/hyperapp",
+    "demo": "https://hyperapp.now-examples.now.sh",
+    "description": "A HyperApp app to get you up and running."
+  },
+  {
     "example": "Polymer",
     "path": "/polymer",
     "demo": "https://polymer.now-examples.now.sh",


### PR DESCRIPTION
This PR adds a HyperApp example, created from the HyperApp boilerplate repository, and updates the `manifest.json` accordingly to offer it as a template in `/new`.

This examples has been tested in local development, the deployment can be found here: https://hyperapp.now-examples.now.sh