### PR TITLE
[jekyll] Speed up build time

### DIFF
--- a/jekyll/package.json
+++ b/jekyll/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "install": "yum install ruby23-devel.x86_64 && gem install jekyll bundler && bundle install",
+    "install": "yum install ruby23-devel.x86_64 && gem install jekyll bundler --no-ri --no-rdoc && bundle install",
     "build": "jekyll build && mv _site public"
   }
 }


### PR DESCRIPTION
This added `--no-ri --no-rdoc` flags to avoid installing unused documentation.

I can't find the official docs on this one but here are references:

- https://coderwall.com/p/spo6bq/default-no-ri-no-rdoc-on-ruby-gem-installation
- https://serverfault.com/a/157252/72332

This cuts the build time in half from 2 minutes down to one minute.

**Update** I found the official docs here: https://guides.rubygems.org/command-reference/#usage-21

* `-​-no-rdoc` - Do not generate RDoc HTML
* ​`--no-ri` - Do not generate RI data