### PR TITLE
Add mdx-deck Example

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -78,6 +78,12 @@
     "description": "A static Docz site that can be expanded upon to create documentation with ease."
   },
   {
+    "example": "mdx-deck",
+    "path": "/mdx-deck",
+    "demo": "https://mdx-deck.now-examples.now.sh",
+    "description": "An mdx-deck presentation template that includes a theme."
+  },
+  {
     "example": "Gridsome",
     "path": "/gridsome",
     "demo": "https://gridsome.now-examples.now.sh",

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,7 @@
     "example": "Nuxt.js",
     "path": "/nuxtjs",
     "demo": "https://nuxtjs.now-examples.now.sh",
-    "description": "A Nuxt.js app, bootstrappd with create-nuxt-app."
+    "description": "A Nuxt.js app, bootstrapped with create-nuxt-app."
   },
   {
     "example": "Create-React-App",

--- a/mdx-deck/.gitignore
+++ b/mdx-deck/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/mdx-deck/.nowignore
+++ b/mdx-deck/.nowignore
@@ -1,0 +1,2 @@
+README.md
+yarn.lock

--- a/mdx-deck/README.md
+++ b/mdx-deck/README.md
@@ -1,0 +1,19 @@
+# mdx-deck Example
+
+This directory is a brief example of a [mdx-deck](https://github.com/jxnblk/mdx-deck) presentation that can be deployed to ZEIT Now with zero configuration.
+
+## How we created this example
+
+To get started with mdx-deck on Now, you can use the [npm init](https://docs.npmjs.com/cli/init) command to initialize the project:
+
+```shell
+$ npm init deck my-presentation
+```
+
+## Deploying this Example
+
+Once initialized, you can deploy the mdx-deck example with just a single command:
+
+```shell
+$ now
+```

--- a/mdx-deck/deck.mdx
+++ b/mdx-deck/deck.mdx
@@ -1,0 +1,24 @@
+import { Head, Notes } from 'mdx-deck'
+import { theme } from './theme'
+
+export const themes = [ theme ]
+
+<Head>
+  <title>Presentation Title</title>
+</Head>
+
+# Hello
+
+---
+
+## Edit this file
+
+To create your presentation
+
+<Notes>
+Create speaker notes with the Notes component
+</Notes>
+
+---
+
+<https://github.com/jxnblk/mdx-deck>

--- a/mdx-deck/package.json
+++ b/mdx-deck/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "name": "foo",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "mdx-deck deck.mdx",
+    "build": "mdx-deck build deck.mdx",
+    "help": "mdx-deck"
+  },
+  "devDependencies": {
+    "mdx-deck": "^3.0.8"
+  }
+}

--- a/mdx-deck/theme.js
+++ b/mdx-deck/theme.js
@@ -1,0 +1,7 @@
+export const theme = {
+  // Customize your presentation theme here.
+  //
+  // Read the docs for more info:
+  // https://github.com/jxnblk/mdx-deck/blob/master/docs/theming.md
+  // https://github.com/jxnblk/mdx-deck/blob/master/docs/themes.md
+}


### PR DESCRIPTION
This PR adds an mdx-deck example generated with the `npm init deck` command. This PR also adds mdx-deck to the manifest, making it available at `/new`.

This example has been tested with a deployment and is available at <https://mdx-deck.now-examples.now.sh/>