### PR TITLE
Update Nuxt.js Build Script

### DIFF
--- a/nuxtjs/package.json
+++ b/nuxtjs/package.json
@@ -6,9 +6,8 @@
   "private": true,
   "scripts": {
     "dev": "nuxt",
-    "build": "nuxt build",
-    "start": "nuxt start",
-    "generate": "nuxt generate"
+    "build": "nuxt generate && mv dist public",
+    "start": "nuxt start"
   },
   "dependencies": {
     "nuxt": "^2.0.0"


### PR DESCRIPTION
This PR updates the Nuxt.js example build script to use `nuxt generate`.