### PR TITLE
Add Metalsmith Example

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -156,6 +156,12 @@
     "description": "A Mithril app to get you up and running."
   },
   {
+    "example": "Metalsmitb",
+    "path": "/metalsmith",
+    "demo": "https://metalsmith.now-examples.now.sh",
+    "description": "A Metalsmith app, created using the static-site starter."
+  },
+  {
     "example": "HyperApp",
     "path": "/hyperapp",
     "demo": "https://hyperapp.now-examples.now.sh",

--- a/metalsmith/.gitignore
+++ b/metalsmith/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/metalsmith/.nowignore
+++ b/metalsmith/.nowignore
@@ -1,0 +1,2 @@
+README.md
+yarn.lock

--- a/metalsmith/Makefile
+++ b/metalsmith/Makefile
@@ -1,0 +1,8 @@
+
+build: node_modules
+	node index.js
+
+node_modules: package.json
+	npm install
+
+.PHONY: build

--- a/metalsmith/README.md
+++ b/metalsmith/README.md
@@ -10,6 +10,8 @@ To get started with Metalsmith on Now, you can use the [Now CLI](https://zeit.co
 $ now init metalsmith
 ```
 
+> The only changes made were to add a build script in `package.json` and change the `destination` in `index.js` to be `"public"`.
+
 ## Deploying this Example
 
 Once initialized, you can deploy the Metalsmith example with just a single command:

--- a/metalsmith/README.md
+++ b/metalsmith/README.md
@@ -1,0 +1,19 @@
+# Metalsmith Example
+
+This directory is a brief example of a [Metalsmith](https://metalsmith.io/) app that can be deployed to ZEIT Now with zero configuration.
+
+## How we created this example
+
+To get started with Metalsmith on Now, you can use the [Now CLI](https://zeit.co/download) to initialize the project:
+
+```shell
+$ now init metalsmith
+```
+
+## Deploying this Example
+
+Once initialized, you can deploy the Metalsmith example with just a single command:
+
+```shell
+$ now
+```

--- a/metalsmith/index.js
+++ b/metalsmith/index.js
@@ -1,0 +1,27 @@
+var Metalsmith = require('metalsmith');
+var markdown = require('metalsmith-markdown');
+var layouts = require('metalsmith-layouts');
+var permalinks = require('metalsmith-permalinks');
+
+Metalsmith(__dirname)
+  .metadata({
+    title: 'My Static Site & Blog',
+    description: "It's about saying »Hello« to the World.",
+    generator: 'Metalsmith',
+    url: 'http://www.metalsmith.io/'
+  })
+  .source('./src')
+  .destination('./public')
+  .clean(false)
+  .use(markdown())
+  .use(permalinks())
+  .use(
+    layouts({
+      engine: 'handlebars'
+    })
+  )
+  .build(function(err, files) {
+    if (err) {
+      throw err;
+    }
+  });

--- a/metalsmith/layouts/layout.html
+++ b/metalsmith/layouts/layout.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>{{ title }}</title>
+  <meta name="description" content="{{ description }}">
+</head>
+<body>
+  <header>
+    <p>
+      <a href="/">Home</a>
+    </p>
+  </header>
+  <h1>{{ title }}</h1>
+  <p>{{ description }}</p>
+
+  {{{ contents }}}
+
+  <footer>
+    <p>Generated with {{ generator }} &mdash; <a href="{{ url }}">{{ url }}</a></p>
+  </footer>
+
+</body>
+</html>

--- a/metalsmith/layouts/post.html
+++ b/metalsmith/layouts/post.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>{{ title }}</title>
+  <meta name="description" content="{{ description }}">
+</head>
+<body>
+  <header>
+    <p>
+      <a href="/">Home</a>
+    </p>
+
+  </header>
+  <h1>{{ title }}</h1>
+  <time>{{ date }}</time>
+  {{{ contents }}}
+
+  <footer>
+    <p>Generated with {{ generator }} &mdash; <a href="{{ url }}">{{ url }}</a></p>
+  </footer>
+</body>
+</html>

--- a/metalsmith/package.json
+++ b/metalsmith/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "static-site-example",
+  "private": true,
+  "dependencies": {
+    "handlebars": "^4.0.5",
+    "metalsmith": "^2.1.0",
+    "metalsmith-layouts": "^1.4.1",
+    "metalsmith-markdown": "^0.2.1",
+    "metalsmith-permalinks": "^0.5.0"
+  },
+  "scripts": {
+    "build": "make build"
+  }
+}

--- a/metalsmith/src/index.md
+++ b/metalsmith/src/index.md
@@ -1,0 +1,13 @@
+---
+layout: layout.html
+---
+
+<h2>Read what I have to say</h2>
+
+<a href="/posts/first-post/">First post</a>
+
+<a href="/posts/second-post/">Second post</a>
+
+<a href="/posts/third-post/">Third post</a>
+
+<a href="/posts/fourth-post/">Fourth post</a>

--- a/metalsmith/src/posts/first-post.md
+++ b/metalsmith/src/posts/first-post.md
@@ -1,0 +1,7 @@
+---
+title: My First Post
+date: 2012-08-20
+layout: post.html
+---
+
+An interesting post about how it's going to be different this time around. I'm going to write a lot more nowadays and use this blog to improve my writing.

--- a/metalsmith/src/posts/fourth-post.md
+++ b/metalsmith/src/posts/fourth-post.md
@@ -1,0 +1,7 @@
+---
+title: My Fourth Post
+date: 2012-12-07
+layout: post.html
+---
+
+A really short, rushed-feeling string of words.

--- a/metalsmith/src/posts/second-post.md
+++ b/metalsmith/src/posts/second-post.md
@@ -1,0 +1,7 @@
+---
+title: My Second Post
+date: 2012-08-23
+layout: post.html
+---
+
+A super-interesting piece of prose I have already written weeks ago.

--- a/metalsmith/src/posts/third-post.md
+++ b/metalsmith/src/posts/third-post.md
@@ -1,0 +1,7 @@
+---
+title: My Third Post
+date: 2012-09-28
+layout: post.html
+---
+
+A slightly late, less interesting piece of prose.


### PR DESCRIPTION
This PR adds a Metalsmith example. It also adds Metalsmith to the `manifest.json` file, making it available at `/new`.

This example has been tested with a deployment, available at: <https://metalsmith.now-examples.now.sh/>