### PR TITLE
Update Nuxt.js Output Directory

### DIFF
--- a/nuxtjs/README.md
+++ b/nuxtjs/README.md
@@ -10,7 +10,7 @@ To get started with Nuxt.js on Now, you can use the [Create-Nuxt-App CLI](https:
 $ npx create-nuxt-app my-app
 ```
 
-> The only change made is to amend the build script in `package.json` to `"nuxt generate && mv dist public"`.
+> The only change made is to amend the output directory in `nuxt.config.js` to `"/public"`.
 
 ## Deploying this Example
 

--- a/nuxtjs/nuxt.config.js
+++ b/nuxtjs/nuxt.config.js
@@ -1,47 +1,47 @@
-
 export default {
   mode: 'spa',
   /*
-  ** Headers of the page
-  */
+   ** Headers of the page
+   */
   head: {
     title: process.env.npm_package_name || '',
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-      { hid: 'description', name: 'description', content: process.env.npm_package_description || '' }
+      {
+        hid: 'description',
+        name: 'description',
+        content: process.env.npm_package_description || ''
+      }
     ],
-    link: [
-      { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }
-    ]
+    link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }]
   },
   /*
-  ** Customize the progress-bar color
-  */
+   ** Customize the progress-bar color
+   */
   loading: { color: '#fff' },
   /*
-  ** Global CSS
-  */
-  css: [
-  ],
+   ** Global CSS
+   */
+  css: [],
   /*
-  ** Plugins to load before mounting the App
-  */
-  plugins: [
-  ],
+   ** Plugins to load before mounting the App
+   */
+  plugins: [],
   /*
-  ** Nuxt.js modules
-  */
-  modules: [
-  ],
+   ** Nuxt.js modules
+   */
+  modules: [],
   /*
-  ** Build configuration
-  */
+   ** Build configuration
+   */
   build: {
     /*
-    ** You can extend webpack config here
-    */
-    extend(config, ctx) {
-    }
+     ** You can extend webpack config here
+     */
+    extend(config, ctx) {}
+  },
+  generate: {
+    dir: 'public'
   }
-}
+};

--- a/nuxtjs/package.json
+++ b/nuxtjs/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "dev": "nuxt",
-    "build": "nuxt generate && mv dist public",
+    "build": "nuxt generate",
     "start": "nuxt start"
   },
   "dependencies": {


### PR DESCRIPTION
This PR updates the Nuxt.js output directory by adding the following code inside `nuxt.config.js`:

``` 
generate: {
    dir: 'public'
}
```

As a result, the build script is changed back to the default.

This has been tested with a new deployment at <https://nuxtjs.now-examples.now.sh/>