### PR TITLE
Improve Jekyll example 

### DIFF
--- a/jekyll/.gitignore
+++ b/jekyll/.gitignore
@@ -1,3 +1,4 @@
 _site
+public
 .sass-cache
 .jekyll-metadata

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -24,6 +24,7 @@ url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb
 github_username:  jekyll
 destination: public
+permalink: pretty
 
 # Build settings
 markdown: kramdown

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -23,6 +23,7 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb
 github_username:  jekyll
+destination: public
 
 # Build settings
 markdown: kramdown

--- a/jekyll/package.json
+++ b/jekyll/package.json
@@ -2,5 +2,6 @@
   "scripts": {
     "now-install": "yum install ruby23-devel.x86_64 && gem install bundler --no-ri --no-rdoc && bundle install",
     "build": "jekyll build && mv _site public",
+    "postinstall": "rm -rf public"
   }
 }

--- a/jekyll/package.json
+++ b/jekyll/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "install": "yum install ruby23-devel.x86_64 && gem install bundler --no-ri --no-rdoc && bundle install",
-    "build": "jekyll build && mv _site public"
+    "now-install": "yum install ruby23-devel.x86_64 && gem install bundler --no-ri --no-rdoc && bundle install",
+    "build": "jekyll build && mv _site public",
   }
 }

--- a/jekyll/package.json
+++ b/jekyll/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "now-install": "yum install ruby23-devel.x86_64 && gem install bundler --no-ri --no-rdoc && bundle install",
+    "install": "yum install ruby23-devel.x86_64 && gem install bundler --no-ri --no-rdoc && bundle install",
     "build": "jekyll build"
   }
 }

--- a/jekyll/package.json
+++ b/jekyll/package.json
@@ -1,7 +1,6 @@
 {
   "scripts": {
     "now-install": "yum install ruby23-devel.x86_64 && gem install bundler --no-ri --no-rdoc && bundle install",
-    "build": "jekyll build && mv _site public",
-    "postinstall": "rm -rf public"
+    "build": "jekyll build"
   }
 }

--- a/jekyll/package.json
+++ b/jekyll/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "install": "yum install ruby23-devel.x86_64 && gem install jekyll bundler --no-ri --no-rdoc && bundle install",
+    "install": "yum install ruby23-devel.x86_64 && gem install bundler --no-ri --no-rdoc && bundle install",
     "build": "jekyll build && mv _site public"
   }
 }

--- a/jekyll/package.json
+++ b/jekyll/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "scripts": {
     "install": "yum install ruby23-devel.x86_64 && gem install bundler --no-ri --no-rdoc && bundle install",
     "build": "jekyll build"


### PR DESCRIPTION
* Remove `jekyll` from the install step — it's superfluous
* ~~Only require installing ruby on production — it breaks `now dev`~~
* Use canonical way to do `public`
* Use pretty permalinks to avoid `.html` suffix