### PR TITLE
Update nextjs example links

### DIFF
--- a/nextjs/components/nav.js
+++ b/nextjs/components/nav.js
@@ -2,7 +2,7 @@ import React from 'react'
 import Link from 'next/link'
 
 const links = [
-  { href: 'https://github.com/segmentio/create-next-app', label: 'Github' }
+  { href: 'https://github.com/zeit/next.js', label: 'Github' }
 ].map(link => {
   link.key = `nav-link-${link.href}-${link.label}`
   return link

--- a/nextjs/components/nav.js
+++ b/nextjs/components/nav.js
@@ -2,7 +2,8 @@ import React from 'react'
 import Link from 'next/link'
 
 const links = [
-  { href: 'https://github.com/zeit/next.js', label: 'Github' }
+  { href: 'https://zeit.co/now', label: 'ZEIT' },
+  { href: 'https://github.com/zeit/next.js', label: 'GitHub' }
 ].map(link => {
   link.key = `nav-link-${link.href}-${link.label}`
   return link
@@ -12,19 +13,15 @@ const Nav = () => (
   <nav>
     <ul>
       <li>
-        <Link prefetch href="/">
+        <Link href='/'>
           <a>Home</a>
         </Link>
       </li>
-      <ul>
-        {links.map(({ key, href, label }) => (
-          <li key={key}>
-            <Link href={href}>
-              <a>{label}</a>
-            </Link>
-          </li>
-        ))}
-      </ul>
+      {links.map(({ key, href, label }) => (
+        <li key={key}>
+          <a href={href}>{label}</a>
+        </li>
+      ))}
     </ul>
 
     <style jsx>{`

--- a/nextjs/pages/index.js
+++ b/nextjs/pages/index.js
@@ -33,25 +33,25 @@ const Home = () => {
         </p>
 
         <div className="row">
-          <Link href="https://github.com/zeit/next.js#getting-started">
+          <Link href="https://nextjs.org/learn/basics/getting-started">
             <a className="card">
               <h3>Getting Started &rarr;</h3>
-              <p>Learn more about Next on Github and in their examples</p>
+              <p>Learn more about Next on the Next.js website</p>
             </a>
           </Link>
-          <Link href="https://open.segment.com/create-next-app">
+          <Link href="https://github.com/zeit/next.js/tree/master/examples/">
             <a className="card">
               <h3>Examples &rarr;</h3>
               <p>
-                Find other example boilerplates on the{' '}
-                <code>create-next-app</code> site
+                Find other examples on the{' '}
+                <code>Next.js</code> Github
               </p>
             </a>
           </Link>
-          <Link href="https://github.com/segmentio/create-next-app">
+          <Link href="https://zeit.co/guides/deploying-nextjs-with-now/">
             <a className="card">
-              <h3>Create Next App &rarr;</h3>
-              <p>Was this tool helpful? Let us know how we can improve it</p>
+              <h3>Deploy with Now &rarr;</h3>
+              <p>Learn how to get your Next.js deployed with a single command</p>
             </a>
           </Link>
         </div>

--- a/nextjs/pages/index.js
+++ b/nextjs/pages/index.js
@@ -32,26 +32,23 @@ const Home = () => {
             : <span className="loading"></span>}
         </p>
 
-        <div className="row">
-          <Link href="https://nextjs.org/learn/basics/getting-started">
-            <a className="card">
+        <div className='row'>
+          <Link href='https://github.com/zeit/next.js#setup'>
+            <a className='card'>
               <h3>Getting Started &rarr;</h3>
-              <p>Learn more about Next on the Next.js website</p>
+              <p>Learn more about Next.js on GitHub and in their examples.</p>
             </a>
           </Link>
-          <Link href="https://github.com/zeit/next.js/tree/master/examples/">
-            <a className="card">
+          <Link href='https://github.com/zeit/next.js/tree/master/examples'>
+            <a className='card'>
               <h3>Examples &rarr;</h3>
-              <p>
-                Find other examples on the{' '}
-                <code>Next.js</code> Github
-              </p>
+              <p>Find other example boilerplates on the Next.js GitHub.</p>
             </a>
           </Link>
-          <Link href="https://zeit.co/guides/deploying-nextjs-with-now/">
-            <a className="card">
-              <h3>Deploy with Now &rarr;</h3>
-              <p>Learn how to get your Next.js deployed with a single command</p>
+          <Link href='https://github.com/zeit/next.js'>
+            <a className='card'>
+              <h3>Create Next App &rarr;</h3>
+              <p>Was this tool helpful? Let us know how we can improve it!</p>
             </a>
           </Link>
         </div>
@@ -96,7 +93,7 @@ const Home = () => {
           width: 176px;
           text-align: center;
         }
-        @keyframes Loading { 
+        @keyframes Loading {
           0%{background-position:0% 50%}
           50%{background-position:100% 50%}
           100%{background-position:0% 50%}


### PR DESCRIPTION
## Issue
The nextjs example has old, deprecated links

## Solution
Update the pages to more closely reflect the example [here](https://github.com/zeit/next.js/tree/canary/packages/create-next-app/templates/default)

## Note
The [example](https://github.com/zeit/next.js/tree/canary/packages/create-next-app/templates/default) doesn't have the Date component but I left it in this one.