### PR TITLE
Fix 404 error for Gatsby starter

### DIFF
--- a/gatsby-functions/src/pages/index.js
+++ b/gatsby-functions/src/pages/index.js
@@ -31,7 +31,7 @@ function Index() {
       </h2>
       <p>
         <a
-          href="https://github.com/zeit/now-examples/blob/master/gatsby-node-typescript"
+          href="https://github.com/zeit/now-examples/blob/master/gatsby-functions"
           target="_blank"
           rel="noreferrer noopener"
         >


### PR DESCRIPTION
Fix 404 error for Gatsby starter on https://gatsby-functions.now-examples.now.sh