### PR TITLE
update vanilla functions link

### DIFF
--- a/vanilla-functions/index.html
+++ b/vanilla-functions/index.html
@@ -14,7 +14,7 @@
     </h2>
     <p>
       <a
-        href="https://github.com/zeit/now-examples/blob/master/vanilla+functions"
+        href="https://github.com/zeit/now-examples/blob/master/vanilla-functions"
         target="_blank"
         rel="noreferrer noopener"
         >This project</a


### PR DESCRIPTION
This PR corrects the link in the `vanilla-functions` example.