### PR TITLE
Added method to directly deploy Jekyll from Github

### DIFF
--- a/jekyll/README.md
+++ b/jekyll/README.md
@@ -2,7 +2,16 @@
 
 This directory is a brief example of a [Jekyll](https://jekyllrb.com/) site that can be deployed to ZEIT Now with zero configuration.
 
-## How we created this example 
+## How to quickly deploy Jekyll to ZEIT Now using Github
+
+1. Copy all files from the "jekyll" folder to a new Github repository.
+2. On the ZEIT Now website, click on "New Project" and chose "From Github".
+3. Chose your repository from step 1 and import it.
+4. Wait for the build to complete.
+5. Open your freshly built Jekyll site on ZEIT Now.
+
+## Manually deploy Jekyll to ZEIT Now
+### How we created this example 
 
 To get started with Jekyll on Now, you can use the [Jekyll CLI](https://jekyllrb.com/docs/usage/) to initialize the project:
 
@@ -10,7 +19,7 @@ To get started with Jekyll on Now, you can use the [Jekyll CLI](https://jekyllrb
 $ jekyll new my-blog
 ```
 
-## Deploying this Example
+### Deploying this Example
 
 Once initialized, you can deploy the Jekyll example with just a single command:
 


### PR DESCRIPTION
It's possible to directly deploy Jekyll from Github to ZEIT Now. With this method it's not necessary to install npm or ruby on your machine.