### PR TITLE
Simplify jekyll example

### DIFF
--- a/jekyll/README.md
+++ b/jekyll/README.md
@@ -10,7 +10,7 @@ To get started with Jekyll on Now, you can use the [Jekyll CLI](https://jekyllrb
 $ jekyll new my-blog
 ```
 
-## How to configure
+## How to Configure
 
 Add a `package.json` file with the following:
 

--- a/jekyll/README.md
+++ b/jekyll/README.md
@@ -23,7 +23,7 @@ Add a `package.json` file with the following:
 }
 ```
 
-This instructs ZEIT Now to build the jekyll website and move the output to the public directory.
+This instructs ZEIT Now to build the Jekyll website and move the output to the public directory.
 
 ## Deploying this Example
 

--- a/jekyll/README.md
+++ b/jekyll/README.md
@@ -10,6 +10,21 @@ To get started with Jekyll on Now, you can use the [Jekyll CLI](https://jekyllrb
 $ jekyll new my-blog
 ```
 
+## How to configure
+
+Add a `package.json` file with the following:
+
+```json
+{
+  "private": true,
+  "scripts": {
+    "build": "jekyll build && mv _site public"
+  }
+}
+```
+
+This instructs ZEIT Now to build the jekyll website and move the output to the public directory.
+
 ## Deploying this Example
 
 Once initialized, you can deploy the Jekyll example with just a single command:

--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -23,7 +23,6 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb
 github_username:  jekyll
-destination: public
 permalink: pretty
 
 # Build settings

--- a/jekyll/package.json
+++ b/jekyll/package.json
@@ -1,7 +1,6 @@
 {
   "private": true,
   "scripts": {
-    "install": "yum install ruby23-devel.x86_64 && gem install bundler --no-ri --no-rdoc && bundle install",
-    "build": "jekyll build"
+    "build": "jekyll build && mv _site public"
   }
 }


### PR DESCRIPTION
We shipped `@now/static-build@canary` which simplifies jekyll (and any ruby static builder) so that `bundle install` is run automatically.

I also update the README.md to explain what the build script is doing.

Related to https://github.com/zeit/now/pull/2980