### PR TITLE
Prevent CRA Opening Browser

### DIFF
--- a/create-react-app-functions/package.json
+++ b/create-react-app-functions/package.json
@@ -8,7 +8,7 @@
     "react-scripts": "2.1.1"
   },
   "scripts": {
-    "dev": "react-scripts start",
+    "dev": "BROWSER=none react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
This PR uses the `BROWSER=none` environment variable to prevent CRA from opening a browser in the functions example. This is based off customer feedback.

Closes #493 