### PR TITLE
Update Aurelia Output Directory

### DIFF
--- a/aurelia/aurelia_project/aurelia.json
+++ b/aurelia/aurelia_project/aurelia.json
@@ -24,7 +24,7 @@
     "hmr": false,
     "open": false,
     "port": 8080,
-    "output": "dist"
+    "output": "public"
   },
   "packageManager": "yarn"
 }


### PR DESCRIPTION
This PR updates the Aurelia output directory to `public`, matching zero configuration requirements.