### PR TITLE
Fix hugo to use pre-installed version

### DIFF
--- a/hugo/package.json
+++ b/hugo/package.json
@@ -1,6 +1,6 @@
 {
+  "private": true",
   "scripts": {
-    "install": "curl -L -O https://github.com/gohugoio/hugo/releases/download/v0.55.6/hugo_0.55.6_Linux-64bit.tar.gz && tar -xzf hugo_0.55.6_Linux-64bit.tar.gz",
-    "build": "./hugo"
+    "build": "hugo"
   }
 }


### PR DESCRIPTION
We support hugo out of the box. Deployments are down to 8 seconds.