### PR TITLE
Add Zola Example

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -190,5 +190,11 @@
     "path": "/eleventy",
     "demo": "https://eleventy.now-examples.now.sh",
     "description": "An Eleventy site, created with npm init."
+  },
+  {
+    "example": "Zola",
+    "path": "/zola",
+    "demo": "https://zola.now-examples.now.sh",
+    "description": "A Zola site, created with the Zola CLI."
   }
 ]

--- a/vuepress/.gitignore
+++ b/vuepress/.gitignore
@@ -1,0 +1,23 @@
+.DS_Store
+node_modules
+/dist
+
+# local env files
+.env.local
+.env.*.local
+.env
+.env.build
+
+# Log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/vuepress/.nowignore
+++ b/vuepress/.nowignore
@@ -1,0 +1,1 @@
+README.md

--- a/zola/.gitignore
+++ b/zola/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+node_modules
+.env
+.env.build
+public

--- a/zola/.nowignore
+++ b/zola/.nowignore
@@ -1,0 +1,2 @@
+README.md
+public

--- a/zola/README.md
+++ b/zola/README.md
@@ -1,0 +1,27 @@
+# Zola Example
+
+This directory is a brief example of a [Zola](https://www.getzola.org/) site that can be deployed with ZEIT Now and zero configuration.
+
+## Deploy Your Own
+
+Deploy your own Zola project with ZEIT Now.
+
+[![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now-examples/tree/master/zola)
+
+_Live Example: https://zola.now-examples.now.sh_
+
+### How We Created This Example
+
+To get started with Zola for deployment with ZEIT Now, you can use the [Zola CLI](https://www.getzola.org/documentation/getting-started/cli-usage/) to initialize the project:
+
+```shell
+$ zola init project-name
+```
+
+### Deploying From Your Terminal
+
+You can deploy your new Zola project with a single command from your terminal using [Now CLI](/download):
+
+```shell
+$ now
+```

--- a/zola/config.toml
+++ b/zola/config.toml
@@ -1,0 +1,15 @@
+# The URL the site will be built for
+base_url = "https://zola.now-examples.now.sh"
+
+# Whether to automatically compile all Sass files in the sass directory
+compile_sass = false
+
+# Whether to do syntax highlighting
+# Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
+highlight_code = false
+
+# Whether to build a search index to be used later on by a JavaScript library
+build_search_index = false
+
+[extra]
+# Put all your custom variables here

--- a/zola/package.json
+++ b/zola/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "zola build"
+    "build": "zola build",
+    "dev": "zola serve --port $PORT"
   },
   "keywords": [],
   "author": "",

--- a/zola/package.json
+++ b/zola/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "my_site",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "zola build"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
This PR adds a Zola example and has been tested with a deployment: https://zola.now-examples.now.sh

It also adds Zola to the manifest and adds missing dotfiles to the VuePress example.