### PR TITLE
Update MkDocs, Pelican and Zola Descriptions

### DIFF
--- a/mkdocs/package.json
+++ b/mkdocs/package.json
@@ -1,7 +1,8 @@
 {
   "name": "mkdocs",
   "version": "1.0.0",
-  "description": "",
+  "private": true,
+  "description": "An MkDocs project, ready for deployment with ZEIT Now.",
   "main": "index.js",
   "directories": {
     "doc": "docs"

--- a/mkdocs/requirements.txt
+++ b/mkdocs/requirements.txt
@@ -1,1 +1,1 @@
-mkdocs
+mkdocs ~= 1.0.4

--- a/pelican/package.json
+++ b/pelican/package.json
@@ -1,7 +1,8 @@
 {
   "name": "pelican",
   "version": "1.0.0",
-  "description": "",
+  "private": true,
+  "description": "A Pelican project, ready for deployment with ZEIT Now.",
   "main": "index.js",
   "scripts": {
     "build": "pelican ./ -o public -s publishconf.py"

--- a/zola/package.json
+++ b/zola/package.json
@@ -1,7 +1,8 @@
 {
   "name": "my_site",
   "version": "1.0.0",
-  "description": "",
+  "private": true,
+  "description": "A Zola project, ready for deployment with ZEIT Now.",
   "main": "index.js",
   "scripts": {
     "build": "zola build",


### PR DESCRIPTION
This PR adds `private:true`, updates descriptions and pins the MkDocs dependency.