### PR TITLE
Fix: Update build command

### DIFF
--- a/vuepress/package.json
+++ b/vuepress/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "vuepress dev docs --port $PORT",
-    "build": "vuepress build docs && mv docs/.vuepress/dist public"
+    "build": "vuepress build docs"
   },
   "devDependencies": {
     "vuepress": "^0.14.4"


### PR DESCRIPTION
on latest `now` - 
`vuepress build docs && mv ./docs/.vuepress/dist public` doesn't work. 
Replacing this `vuepress build docs` resolves this issue

using the original command will result in prolonged build time and an error of 
 '/fargate/37ff0f75/docs' does not exist.