### PR TITLE
Fix VuePress Example

### DIFF
--- a/vuepress/.nowignore
+++ b/vuepress/.nowignore
@@ -1,1 +1,1 @@
-README.md
+yarn.lock

--- a/vuepress/README.md
+++ b/vuepress/README.md
@@ -8,7 +8,7 @@ Deploy your own VuePress project with ZEIT Now.
 
 [![Deploy with ZEIT Now](https://zeit.co/button)](https://zeit.co/new/project?template=https://github.com/zeit/now-examples/tree/master/vuepress)
 
-*Live Example: https://vuepress.now-examples.now.sh*
+_Live Example: https://vuepress.now-examples.now.sh_
 
 ### How We Created This Example
 
@@ -18,7 +18,7 @@ To get started with VuePress deployed with ZEIT Now, you can use the [Now CLI](h
 $ now init vuepress
 ```
 
-> The only change made is to add `&& mv docs/.vuepress/dist public` to the build script in the `package.json` file.
+> The only change made is to add `dest: "/public"` to the `config.js` file.
 
 ### Deploying From Your Terminal
 

--- a/vuepress/docs/.vuepress/config.js
+++ b/vuepress/docs/.vuepress/config.js
@@ -1,11 +1,12 @@
 module.exports = {
-  title: 'Vuepress',
-  description: 'This is a Zeit Now 2.0 example',
+  title: "Vuepress",
+  description: "This is a Zeit Now 2.0 example",
   themeConfig: {
     nav: [
-      { text: 'Home', link: '/' },
-      { text: 'Guide', link: '/guide/' },
-      { text: 'Config Page', link: '/config' },
+      { text: "Home", link: "/" },
+      { text: "Guide", link: "/guide/" },
+      { text: "Config Page", link: "/config" }
     ]
-  }
-}
+  },
+  dest: "/public"
+};

--- a/vuepress/package.json
+++ b/vuepress/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "vuepress dev docs --port $PORT",
-    "build": "vuepress build docs && mv docs/.vuepress/dist public"
+    "build": "vuepress build docs"
   },
   "devDependencies": {
     "vuepress": "^0.14.4"


### PR DESCRIPTION
This PR fixes the VuePress example by removing `README.md` from the `.nowignore` file, it also uses config based output directory changes instead of moving the directory.