### PR TITLE
Remove package.json Warnings

### DIFF
--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -1,5 +1,11 @@
 {
   "name": "create-next-example-app",
+  "description": "A Next.js starter app.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zeit/now-examples/tree/master/nextjs"
+  },
+  "license": "MIT",
   "scripts": {
     "dev": "next",
     "build": "next build",


### PR DESCRIPTION
This PR removes three `package.json` warnings by adding `description`, `repository`, and `license` fields to the Next.js example.