### PR TITLE
Mention change in docs directory in Docusaurus example

### DIFF
--- a/docusaurus/README.md
+++ b/docusaurus/README.md
@@ -4,6 +4,8 @@
 
 This directory is a brief example of a [Docusaurus](https://docusaurus.io/) site that can be deployed with ZEIT Now and zero configuration.
 
+> Note that your `docs` directory has to be within the `website` directory, ideally following the directory structure in this example. You will also have to specify a `customDocsPath` value in `siteConfig.js`. Take a look at the `siteConfig.js` file here for reference.
+
 ## Deploy Your Own
 
 Deploy your own Docusaurus project with ZEIT Now.

--- a/docusaurus/README.md
+++ b/docusaurus/README.md
@@ -4,7 +4,7 @@
 
 This directory is a brief example of a [Docusaurus](https://docusaurus.io/) site that can be deployed with ZEIT Now and zero configuration.
 
-> Note that your `docs` directory has to be within the `website` directory, ideally following the directory structure in this example. You will also have to specify a `customDocsPath` value in `siteConfig.js`. Take a look at the `siteConfig.js` file here for reference.
+> Note that the directory structure Now supports is slightly different from the default directory structure of a Docusaurus project - The `docs` directory has to be within the `website` directory, ideally following the directory structure in this example. You will also have to specify a `customDocsPath` value in `siteConfig.js`. Take a look at the `siteConfig.js` file here for reference.
 
 ## Deploy Your Own
 


### PR DESCRIPTION
Now's deployment doesn't allow files outside the root directory whereas Docusaurus' default example has the `docs` directory outside the `website` directory. The workaround Now took was to shift the `docs` directory into the `website` and specify `customDocsPath` in `siteConfig.js`. However, this isn't obvious and should be made known to users.