### PR TITLE
Update nuxt.config.js

### DIFF
--- a/nuxtjs/nuxt.config.js
+++ b/nuxtjs/nuxt.config.js
@@ -40,8 +40,5 @@ export default {
      ** You can extend webpack config here
      */
     extend(config, ctx) {}
-  },
-  generate: {
-    dir: 'public'
   }
 };


### PR DESCRIPTION
Now we detect Nuxt.js and optimize the default folder. This example has stopped working and if you remove the configuration regarding the output directory, it starts working again.